### PR TITLE
Add login and two-step registration endpoints

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\Student;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    public function showLoginForm()
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required','email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+            return redirect('/');
+        }
+
+        return back()->withErrors([
+            'email' => 'The provided credentials do not match our records.',
+        ])->onlyInput('email');
+    }
+
+    public function showRegisterForm(Request $request)
+    {
+        $step = session('register.step', 1);
+        $data = session('register.data', []);
+        return view('auth.register', compact('step','data'));
+    }
+
+    public function handleRegister(Request $request)
+    {
+        $step = session('register.step', 1);
+
+        if ($step === 1) {
+            $validated = $request->validate([
+                'name' => 'required|string',
+                'email' => 'required|email|unique:users,email',
+                'password' => 'required|min:8',
+                'phone' => 'required|numeric',
+                'role' => 'required|in:student,supervisor,admin,developer',
+            ]);
+
+            session(['register.step' => 2, 'register.data' => $validated]);
+            return redirect()->route('register.show');
+        }
+
+        $data = session('register.data');
+        if (!$data) {
+            return redirect()->route('register.show');
+        }
+
+        if ($data['role'] === 'student') {
+            $validated = $request->validate([
+                'student_number' => 'required|numeric',
+                'national_sn' => 'required|numeric',
+                'major' => 'required|string',
+                'batch' => 'required|date_format:Y',
+                'photo' => 'nullable|string',
+            ]);
+        } else {
+            $validated = [];
+        }
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => $data['password'],
+            'phone' => $data['phone'],
+            'role' => $data['role'],
+        ]);
+
+        if ($data['role'] === 'student') {
+            Student::create([
+                'user_id' => $user->id,
+                'student_number' => $validated['student_number'],
+                'national_sn' => $validated['national_sn'],
+                'major' => $validated['major'],
+                'batch' => $validated['batch'],
+                'photo' => $validated['photo'] ?? null,
+            ]);
+        }
+
+        session()->forget('register');
+        return redirect()->route('login.show')->with('status', 'Registration successful.');
+    }
+}
+

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Student extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'student_number',
+        'national_sn',
+        'major',
+        'batch',
+        'photo',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Student;
 
 class User extends Authenticatable
 {
@@ -21,6 +22,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'phone',
+        'role',
     ];
 
     /**
@@ -44,5 +47,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function student()
+    {
+        return $this->hasOne(Student::class);
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+@if (session('status'))
+    <div>{{ session('status') }}</div>
+@endif
+@if ($errors->any())
+    <div>
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form method="POST" action="{{ route('login.perform') }}">
+    @csrf
+    <div>
+        <label>Email</label>
+        <input type="email" name="email" value="{{ old('email') }}" required>
+    </div>
+    <div>
+        <label>Password</label>
+        <input type="password" name="password" required>
+    </div>
+    <button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+</head>
+<body>
+@if ($errors->any())
+    <div>
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+@if ($step === 1)
+<form method="POST" action="{{ route('register.handle') }}">
+    @csrf
+    <div>
+        <label>Name</label>
+        <input type="text" name="name" value="{{ old('name', $data['name'] ?? '') }}" required>
+    </div>
+    <div>
+        <label>Email</label>
+        <input type="email" name="email" value="{{ old('email', $data['email'] ?? '') }}" required>
+    </div>
+    <div>
+        <label>Password</label>
+        <input type="password" name="password" required>
+    </div>
+    <div>
+        <label>Phone</label>
+        <input type="number" name="phone" value="{{ old('phone', $data['phone'] ?? '') }}" required>
+    </div>
+    <div>
+        <label>Role</label>
+        <select name="role" required>
+            <option value="">Select role</option>
+            @foreach (['student','supervisor','admin','developer'] as $role)
+                <option value="{{ $role }}" {{ (old('role', $data['role'] ?? '') === $role) ? 'selected' : '' }}>{{ ucfirst($role) }}</option>
+            @endforeach
+        </select>
+    </div>
+    <button type="submit">Next</button>
+</form>
+@else
+<form method="POST" action="{{ route('register.handle') }}">
+    @csrf
+    @if (($data['role'] ?? '') === 'student')
+    <div>
+        <label>Student Number</label>
+        <input type="number" name="student_number" value="{{ old('student_number') }}" required>
+    </div>
+    <div>
+        <label>National Student Number</label>
+        <input type="number" name="national_sn" value="{{ old('national_sn') }}" required>
+    </div>
+    <div>
+        <label>Major</label>
+        <input type="text" name="major" value="{{ old('major') }}" required>
+    </div>
+    <div>
+        <label>Batch</label>
+        <input type="number" name="batch" value="{{ old('batch') }}" required>
+    </div>
+    <div>
+        <label>Photo (link)</label>
+        <input type="text" name="photo" value="{{ old('photo') }}">
+    </div>
+    @endif
+    <button type="submit">Sign Up</button>
+</form>
+@endif
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('auth/login', [AuthController::class, 'showLoginForm'])->name('login.show');
+Route::post('auth/login', [AuthController::class, 'login'])->name('login.perform');
+
+Route::get('auth/register', [AuthController::class, 'showRegisterForm'])->name('register.show');
+Route::post('auth/register', [AuthController::class, 'handleRegister'])->name('register.handle');


### PR DESCRIPTION
## Summary
- add `/auth/login` and `/auth/register` routes
- implement AuthController with login and two-step registration (student role fields)
- create Student model and extend User model with phone/role
- add views for login and registration forms

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub 403 requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b7e72a108331bec0042c03ee6131