### PR TITLE
Add student management endpoints and sidebar layout

### DIFF
--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -15,6 +15,7 @@ class Student extends Model
         'national_sn',
         'major',
         'batch',
+        'notes',
         'photo',
     ];
 

--- a/database/migrations/2024_01_01_000003_create_student_views.php
+++ b/database/migrations/2024_01_01_000003_create_student_views.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW student_details_view AS
+            SELECT s.id,
+                   u.id AS user_id,
+                   u.name,
+                   u.email,
+                   u.phone,
+                   u.role,
+                   s.student_number,
+                   s.national_sn,
+                   s.major,
+                   s.batch,
+                   s.notes,
+                   s.photo
+            FROM students s
+            JOIN users u ON s.user_id = u.id;
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS student_details_view;');
+    }
+};

--- a/resources/views/application.blade.php
+++ b/resources/views/application.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('title', 'Applications')
+
+@section('content')
+@endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard')
+
+@section('content')
+@endsection

--- a/resources/views/internship.blade.php
+++ b/resources/views/internship.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('title', 'Internships')
+
+@section('content')
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>@yield('title', 'Internish')</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="bg-light border-end" style="min-width:200px;">
+        <div class="list-group list-group-flush">
+            <a href="/student" class="list-group-item list-group-item-action">Students</a>
+            <a href="/supervisor" class="list-group-item list-group-item-action">Supervisors</a>
+            <a href="/application" class="list-group-item list-group-item-action">Applications</a>
+            <a href="/internship" class="list-group-item list-group-item-action">Internships</a>
+            <a href="/monitor" class="list-group-item list-group-item-action">Monitors</a>
+        </div>
+    </nav>
+    <main class="p-4 flex-fill">
+        @yield('content')
+    </main>
+</div>
+</body>
+</html>

--- a/resources/views/monitor.blade.php
+++ b/resources/views/monitor.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('title', 'Monitors')
+
+@section('content')
+@endsection

--- a/resources/views/student/create.blade.php
+++ b/resources/views/student/create.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Add Student')
+
+@section('content')
+<h1>Add Student</h1>
+@include('student.form', ['action' => '/student', 'method' => 'POST', 'student' => null])
+@endsection

--- a/resources/views/student/edit.blade.php
+++ b/resources/views/student/edit.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Student')
+
+@section('content')
+<h1>Edit Student</h1>
+@include('student.form', ['action' => '/student/' . $student->id, 'method' => 'PUT', 'student' => $student])
+@endsection

--- a/resources/views/student/form.blade.php
+++ b/resources/views/student/form.blade.php
@@ -1,0 +1,48 @@
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if($method === 'PUT')
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', optional($student)->name) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ old('email', optional($student)->email) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ old('phone', optional($student)->phone) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Student Number</label>
+        <input type="text" name="student_number" class="form-control" value="{{ old('student_number', optional($student)->student_number) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">National Student Number</label>
+        <input type="text" name="national_sn" class="form-control" value="{{ old('national_sn', optional($student)->national_sn) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Major</label>
+        <input type="text" name="major" class="form-control" value="{{ old('major', optional($student)->major) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Batch</label>
+        <input type="text" name="batch" class="form-control" value="{{ old('batch', optional($student)->batch) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control">{{ old('notes', optional($student)->notes) }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Photo</label>
+        <input type="text" name="photo" class="form-control" value="{{ old('photo', optional($student)->photo) }}">
+    </div>
+    <a href="/student" class="btn btn-secondary">Back</a>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/resources/views/student/index.blade.php
+++ b/resources/views/student/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('title', 'Students')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h1>Students</h1>
+    <a href="/student/add" class="btn btn-primary">Add</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Student Number</th>
+            <th>Name</th>
+            <th>Major</th>
+            <th>Batch</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($students as $student)
+        <tr>
+            <td>{{ $student->student_number }}</td>
+            <td>{{ $student->name }}</td>
+            <td>{{ $student->major }}</td>
+            <td>{{ $student->batch }}</td>
+            <td>
+                <a href="/student/{{ $student->id }}/see" class="btn btn-sm btn-secondary">View</a>
+                <a href="/student/{{ $student->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                <form action="/student/{{ $student->id }}" method="POST" style="display:inline-block">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @empty
+        <tr><td colspan="5">No students found.</td></tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/resources/views/student/show.blade.php
+++ b/resources/views/student/show.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('title', 'Student Details')
+
+@section('content')
+<h1>Student Details</h1>
+<div class="row">
+    <div class="col-md-3">
+        @if($student->photo)
+            <img src="{{ $student->photo }}" alt="{{ $student->name }}" class="img-fluid">
+        @else
+            <div class="bg-secondary text-white text-center p-3">No Photo</div>
+        @endif
+    </div>
+    <div class="col-md-9">
+        <ul class="list-unstyled">
+            <li><strong>{{ $student->name }}</strong></li>
+            <li>Email: {{ $student->email }}</li>
+            <li>Phone: {{ $student->phone }}</li>
+            <li>Role: {{ $student->role }}</li>
+            <li>User ID: {{ $student->user_id }}</li>
+            <li>Student Number: {{ $student->student_number }}</li>
+            <li>National Student Number: {{ $student->national_sn }}</li>
+            <li>Major: {{ $student->major }}</li>
+            <li>Batch: {{ $student->batch }}</li>
+            <li>Notes: {{ $student->notes }}</li>
+        </ul>
+    </div>
+</div>
+<a href="/student" class="btn btn-secondary mt-3">Back</a>
+@endsection

--- a/resources/views/supervisor.blade.php
+++ b/resources/views/supervisor.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('title', 'Supervisors')
+
+@section('content')
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,9 +2,23 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\StudentController;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::view('/', 'home');
+Route::view('/dashboard', 'home');
+Route::view('/supervisor', 'supervisor');
+Route::view('/application', 'application');
+Route::view('/internship', 'internship');
+Route::view('/monitor', 'monitor');
+
+Route::prefix('student')->group(function () {
+    Route::get('/', [StudentController::class, 'index']);
+    Route::get('/add', [StudentController::class, 'create']);
+    Route::post('/', [StudentController::class, 'store']);
+    Route::get('{id}/see', [StudentController::class, 'show']);
+    Route::get('{id}/edit', [StudentController::class, 'edit']);
+    Route::put('{id}', [StudentController::class, 'update']);
+    Route::delete('{id}', [StudentController::class, 'destroy']);
 });
 
 Route::get('auth/login', [AuthController::class, 'showLoginForm'])->name('login.show');


### PR DESCRIPTION
## Summary
- Introduce shared layout with sidebar navigation and stub pages
- Implement full student CRUD with list, detail, create, edit and delete
- Add database view for student details

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= SESSION_DRIVER=array DB_CONNECTION=sqlite php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c621a0a8833182316bb7a3b03f51