### PR TITLE
Add supervisor CRUD endpoints and views

### DIFF
--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Supervisor;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class SupervisorController extends Controller
+{
+    public function index()
+    {
+        $supervisors = DB::table('supervisor_details_view')
+            ->select('id', 'supervisor_number', 'name', 'department')
+            ->orderBy('supervisor_number')
+            ->get();
+
+        return view('supervisor.index', compact('supervisors'));
+    }
+
+    public function show($id)
+    {
+        $supervisor = DB::table('supervisor_details_view')->where('id', $id)->first();
+        abort_if(!$supervisor, 404);
+        return view('supervisor.show', compact('supervisor'));
+    }
+
+    public function create()
+    {
+        return view('supervisor.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email',
+            'phone' => 'nullable|string',
+            'password' => 'required|string',
+            'supervisor_number' => 'required|string|unique:supervisors,supervisor_number',
+            'department' => 'required|string',
+            'notes' => 'nullable|string',
+            'photo' => 'nullable|string',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'phone' => $data['phone'] ?? null,
+            'password' => Hash::make($data['password']),
+            'role' => 'supervisor',
+        ]);
+
+        Supervisor::create([
+            'user_id' => $user->id,
+            'supervisor_number' => $data['supervisor_number'],
+            'department' => $data['department'],
+            'notes' => $data['notes'] ?? null,
+            'photo' => $data['photo'] ?? null,
+        ]);
+
+        return redirect('/supervisor');
+    }
+
+    public function edit($id)
+    {
+        $supervisor = DB::table('supervisor_details_view')->where('id', $id)->first();
+        abort_if(!$supervisor, 404);
+        return view('supervisor.edit', compact('supervisor'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $supervisor = Supervisor::findOrFail($id);
+        $user = $supervisor->user;
+
+        $data = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email,' . $user->id,
+            'phone' => 'nullable|string',
+            'password' => 'nullable|string',
+            'supervisor_number' => 'required|string|unique:supervisors,supervisor_number,' . $supervisor->id,
+            'department' => 'required|string',
+            'notes' => 'nullable|string',
+            'photo' => 'nullable|string',
+        ]);
+
+        $user->name = $data['name'];
+        $user->email = $data['email'];
+        $user->phone = $data['phone'] ?? null;
+        if (!empty($data['password'])) {
+            $user->password = Hash::make($data['password']);
+        }
+        $user->save();
+
+        $supervisor->update([
+            'supervisor_number' => $data['supervisor_number'],
+            'department' => $data['department'],
+            'notes' => $data['notes'] ?? null,
+            'photo' => $data['photo'] ?? null,
+        ]);
+
+        return redirect('/supervisor');
+    }
+
+    public function destroy($id)
+    {
+        $supervisor = Supervisor::findOrFail($id);
+        $supervisor->user()->delete();
+        return redirect('/supervisor');
+    }
+}

--- a/app/Models/Supervisor.php
+++ b/app/Models/Supervisor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Supervisor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'supervisor_number',
+        'department',
+        'notes',
+        'photo',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2024_01_01_000004_create_supervisor_views.php
+++ b/database/migrations/2024_01_01_000004_create_supervisor_views.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW supervisor_details_view AS
+            SELECT s.id,
+                   u.id AS user_id,
+                   u.name,
+                   u.email,
+                   u.phone,
+                   u.role,
+                   s.supervisor_number,
+                   s.department,
+                   s.notes,
+                   s.photo
+            FROM supervisors s
+            JOIN users u ON s.user_id = u.id;
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS supervisor_details_view;');
+    }
+};

--- a/resources/views/components/form-errors.blade.php
+++ b/resources/views/components/form-errors.blade.php
@@ -1,0 +1,9 @@
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/student/form.blade.php
+++ b/resources/views/student/form.blade.php
@@ -3,6 +3,8 @@
     @if($method === 'PUT')
         @method('PUT')
     @endif
+
+    @include('components.form-errors')
     <div class="mb-3">
         <label class="form-label">Name</label>
         <input type="text" name="name" class="form-control" value="{{ old('name', optional($student)->name) }}">

--- a/resources/views/supervisor.blade.php
+++ b/resources/views/supervisor.blade.php
@@ -1,6 +1,0 @@
-@extends('layouts.app')
-
-@section('title', 'Supervisors')
-
-@section('content')
-@endsection

--- a/resources/views/supervisor/create.blade.php
+++ b/resources/views/supervisor/create.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Add Supervisor')
+
+@section('content')
+<h1>Add Supervisor</h1>
+@include('supervisor.form', ['action' => '/supervisor', 'method' => 'POST', 'supervisor' => null])
+@endsection

--- a/resources/views/supervisor/edit.blade.php
+++ b/resources/views/supervisor/edit.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Supervisor')
+
+@section('content')
+<h1>Edit Supervisor</h1>
+@include('supervisor.form', ['action' => '/supervisor/' . $supervisor->id, 'method' => 'PUT', 'supervisor' => $supervisor])
+@endsection

--- a/resources/views/supervisor/form.blade.php
+++ b/resources/views/supervisor/form.blade.php
@@ -1,0 +1,43 @@
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if($method === 'PUT')
+        @method('PUT')
+    @endif
+
+    @include('components.form-errors')
+
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', optional($supervisor)->name) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ old('email', optional($supervisor)->email) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ old('phone', optional($supervisor)->phone) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Supervisor Number</label>
+        <input type="text" name="supervisor_number" class="form-control" value="{{ old('supervisor_number', optional($supervisor)->supervisor_number) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Department</label>
+        <input type="text" name="department" class="form-control" value="{{ old('department', optional($supervisor)->department) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control">{{ old('notes', optional($supervisor)->notes) }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Photo</label>
+        <input type="text" name="photo" class="form-control" value="{{ old('photo', optional($supervisor)->photo) }}">
+    </div>
+    <a href="/supervisor" class="btn btn-secondary">Back</a>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/resources/views/supervisor/index.blade.php
+++ b/resources/views/supervisor/index.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('title', 'Supervisors')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h1>Supervisors</h1>
+    <a href="/supervisor/add" class="btn btn-primary">Add</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Supervisor Number</th>
+            <th>Name</th>
+            <th>Department</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($supervisors as $supervisor)
+        <tr>
+            <td>{{ $supervisor->supervisor_number }}</td>
+            <td>{{ $supervisor->name }}</td>
+            <td>{{ $supervisor->department }}</td>
+            <td>
+                <a href="/supervisor/{{ $supervisor->id }}/see" class="btn btn-sm btn-secondary">View</a>
+                <a href="/supervisor/{{ $supervisor->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                <form action="/supervisor/{{ $supervisor->id }}" method="POST" style="display:inline-block">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @empty
+        <tr><td colspan="4">No supervisors found.</td></tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/resources/views/supervisor/show.blade.php
+++ b/resources/views/supervisor/show.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('title', 'Supervisor Details')
+
+@section('content')
+<h1>Supervisor Details</h1>
+<div class="row">
+    <div class="col-md-3">
+        @if($supervisor->photo)
+            <img src="{{ $supervisor->photo }}" alt="{{ $supervisor->name }}" class="img-fluid">
+        @else
+            <div class="bg-secondary text-white text-center p-3">No Photo</div>
+        @endif
+    </div>
+    <div class="col-md-9">
+        <ul class="list-unstyled">
+            <li><strong>{{ $supervisor->name }}</strong></li>
+            <li>Email: {{ $supervisor->email }}</li>
+            <li>Phone: {{ $supervisor->phone }}</li>
+            <li>Role: {{ $supervisor->role }}</li>
+            <li>User ID: {{ $supervisor->user_id }}</li>
+            <li>Supervisor Number: {{ $supervisor->supervisor_number }}</li>
+            <li>Department: {{ $supervisor->department }}</li>
+            <li>Notes: {{ $supervisor->notes }}</li>
+        </ul>
+    </div>
+</div>
+<a href="/supervisor" class="btn btn-secondary mt-3">Back</a>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,10 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\StudentController;
+use App\Http\Controllers\SupervisorController;
 
 Route::view('/', 'home');
 Route::view('/dashboard', 'home');
-Route::view('/supervisor', 'supervisor');
 Route::view('/application', 'application');
 Route::view('/internship', 'internship');
 Route::view('/monitor', 'monitor');
@@ -19,6 +19,16 @@ Route::prefix('student')->group(function () {
     Route::get('{id}/edit', [StudentController::class, 'edit']);
     Route::put('{id}', [StudentController::class, 'update']);
     Route::delete('{id}', [StudentController::class, 'destroy']);
+});
+
+Route::prefix('supervisor')->group(function () {
+    Route::get('/', [SupervisorController::class, 'index']);
+    Route::get('/add', [SupervisorController::class, 'create']);
+    Route::post('/', [SupervisorController::class, 'store']);
+    Route::get('{id}/see', [SupervisorController::class, 'show']);
+    Route::get('{id}/edit', [SupervisorController::class, 'edit']);
+    Route::put('{id}', [SupervisorController::class, 'update']);
+    Route::delete('{id}', [SupervisorController::class, 'destroy']);
 });
 
 Route::get('auth/login', [AuthController::class, 'showLoginForm'])->name('login.show');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,14 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'session.driver' => 'array',
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- implement SupervisorController, model, and routes for full CRUD operations
- add supervisor migration view and Blade templates for listing, viewing, adding, editing
- introduce reusable form error component shared by student and supervisor forms

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b41392e4d483318dea9028e74f3fdb