### PR TITLE
Add internship CRUD

### DIFF
--- a/app/Http/Controllers/InternshipController.php
+++ b/app/Http/Controllers/InternshipController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Internship;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class InternshipController extends Controller
+{
+    private function statusOptions(): array
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'pgsql') {
+            return collect(DB::select("SELECT unnest(enum_range(NULL::internship_status_enum)) AS status"))->pluck('status')->all();
+        }
+        return ['planned', 'ongoing', 'completed', 'terminated'];
+    }
+
+    public function index()
+    {
+        $internships = DB::table('internship_details_view')
+            ->select('id', 'student_name', 'institution_name', 'start_date', 'end_date')
+            ->orderBy('id')
+            ->get();
+        return view('internship.index', compact('internships'));
+    }
+
+    public function show($id)
+    {
+        $internship = DB::table('internship_details_view')->where('id', $id)->first();
+        abort_if(!$internship, 404);
+        return view('internship.show', compact('internship'));
+    }
+
+    public function create()
+    {
+        $applications = DB::table('application_details_view')
+            ->select('id', 'student_name', 'institution_name')
+            ->orderBy('id')
+            ->get();
+        $statuses = $this->statusOptions();
+        return view('internship.create', compact('applications', 'statuses'));
+    }
+
+    public function store(Request $request)
+    {
+        $statuses = $this->statusOptions();
+        $data = $request->validate([
+            'application_id' => 'required|exists:applications,id',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after_or_equal:start_date',
+            'status' => 'required|in:' . implode(',', $statuses),
+        ]);
+
+        $app = DB::table('applications')
+            ->select('student_id', 'institution_id', 'period_id')
+            ->where('id', $data['application_id'])
+            ->first();
+        abort_if(!$app, 400);
+        $data['student_id'] = $app->student_id;
+        $data['institution_id'] = $app->institution_id;
+        $data['period_id'] = $app->period_id;
+
+        Internship::create($data);
+        return redirect('/internship');
+    }
+
+    public function edit($id)
+    {
+        $internship = DB::table('internship_details_view')->where('id', $id)->first();
+        abort_if(!$internship, 404);
+        $applications = DB::table('application_details_view')
+            ->select('id', 'student_name', 'institution_name')
+            ->orderBy('id')
+            ->get();
+        $statuses = $this->statusOptions();
+        return view('internship.edit', compact('internship', 'applications', 'statuses'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $internship = Internship::findOrFail($id);
+        $statuses = $this->statusOptions();
+        $data = $request->validate([
+            'application_id' => 'required|exists:applications,id',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after_or_equal:start_date',
+            'status' => 'required|in:' . implode(',', $statuses),
+        ]);
+
+        $app = DB::table('applications')
+            ->select('student_id', 'institution_id', 'period_id')
+            ->where('id', $data['application_id'])
+            ->first();
+        abort_if(!$app, 400);
+        $data['student_id'] = $app->student_id;
+        $data['institution_id'] = $app->institution_id;
+        $data['period_id'] = $app->period_id;
+
+        $internship->update($data);
+        return redirect('/internship');
+    }
+
+    public function destroy($id)
+    {
+        $internship = Internship::findOrFail($id);
+        $internship->delete();
+        return redirect('/internship');
+    }
+}

--- a/app/Models/Internship.php
+++ b/app/Models/Internship.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Internship extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'application_id',
+        'student_id',
+        'institution_id',
+        'period_id',
+        'start_date',
+        'end_date',
+        'status',
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+    ];
+}

--- a/database/migrations/2024_01_01_000008_create_internship_views.php
+++ b/database/migrations/2024_01_01_000008_create_internship_views.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW internship_details_view AS
+            SELECT it.id,
+                   it.application_id,
+                   it.student_id,
+                   u.name AS student_name,
+                   it.institution_id,
+                   i.name AS institution_name,
+                   it.period_id,
+                   p.year AS period_year,
+                   p.term AS period_term,
+                   it.start_date,
+                   it.end_date,
+                   it.status
+            FROM internships it
+            JOIN students s ON s.id = it.student_id
+            JOIN users u ON u.id = s.user_id
+            JOIN institutions i ON i.id = it.institution_id
+            JOIN periods p ON p.id = it.period_id;
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS internship_details_view;');
+    }
+};

--- a/resources/views/internship.blade.php
+++ b/resources/views/internship.blade.php
@@ -1,6 +1,0 @@
-@extends('layouts.app')
-
-@section('title', 'Internships')
-
-@section('content')
-@endsection

--- a/resources/views/internship/create.blade.php
+++ b/resources/views/internship/create.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('title', 'Add Internship')
+
+@section('content')
+<h1>Add Internship</h1>
+@include('internship.form', [
+    'action' => '/internship',
+    'method' => 'POST',
+    'internship' => null,
+    'applications' => $applications,
+    'statuses' => $statuses,
+    'readonly' => false,
+])
+@endsection

--- a/resources/views/internship/edit.blade.php
+++ b/resources/views/internship/edit.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Internship')
+
+@section('content')
+<h1>Edit Internship</h1>
+@include('internship.form', [
+    'action' => '/internship/' . $internship->id,
+    'method' => 'PUT',
+    'internship' => $internship,
+    'applications' => $applications,
+    'statuses' => $statuses,
+    'readonly' => true,
+])
+@endsection

--- a/resources/views/internship/form.blade.php
+++ b/resources/views/internship/form.blade.php
@@ -1,0 +1,42 @@
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if($method === 'PUT')
+        @method('PUT')
+    @endif
+
+    @include('components.form-errors')
+
+    <div class="mb-3">
+        <label class="form-label">Application</label>
+        <select name="application_id" class="form-select" {{ $readonly ? 'disabled' : '' }}>
+            @foreach($applications as $application)
+                <option value="{{ $application->id }}" {{ old('application_id', optional($internship)->application_id) == $application->id ? 'selected' : '' }}>{{ $application->student_name }} – {{ $application->institution_name }}</option>
+            @endforeach
+        </select>
+        @if($readonly)
+            <input type="hidden" name="application_id" value="{{ old('application_id', optional($internship)->application_id) }}">
+        @endif
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Start Date</label>
+        <input type="date" name="start_date" class="form-control" value="{{ old('start_date', optional($internship)->start_date ? \Illuminate\Support\Carbon::parse($internship->start_date)->format('Y-m-d') : '') }}">
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">End Date</label>
+        <input type="date" name="end_date" class="form-control" value="{{ old('end_date', optional($internship)->end_date ? \Illuminate\Support\Carbon::parse($internship->end_date)->format('Y-m-d') : '') }}">
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+            @foreach($statuses as $status)
+                <option value="{{ $status }}" {{ old('status', optional($internship)->status) == $status ? 'selected' : '' }}>{{ $status }}</option>
+            @endforeach
+        </select>
+    </div>
+
+    <a href="/internship" class="btn btn-secondary">Back</a>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/resources/views/internship/index.blade.php
+++ b/resources/views/internship/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('title', 'Internships')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h1>Internships</h1>
+    <a href="/internship/add" class="btn btn-primary">Add</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Student Name</th>
+            <th>Institution Name</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($internships as $internship)
+        <tr>
+            <td>{{ $internship->student_name }}</td>
+            <td>{{ $internship->institution_name }}</td>
+            <td>{{ $internship->start_date }}</td>
+            <td>{{ $internship->end_date }}</td>
+            <td>
+                <a href="/internship/{{ $internship->id }}/see" class="btn btn-sm btn-secondary">View</a>
+                <a href="/internship/{{ $internship->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                <form action="/internship/{{ $internship->id }}" method="POST" style="display:inline-block">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @empty
+        <tr><td colspan="5">No internships found.</td></tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/resources/views/internship/show.blade.php
+++ b/resources/views/internship/show.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('title', 'Internship Details')
+
+@section('content')
+<h1><a href="/application/{{ $internship->application_id }}/see">{{ $internship->student_name }} – {{ $internship->institution_name }}</a></h1>
+<ul class="list-unstyled">
+    <li>Start Date: {{ $internship->start_date }}</li>
+    <li>End Date: {{ $internship->end_date }}</li>
+    <li>Status: {{ $internship->status }}</li>
+</ul>
+<a href="/internship" class="btn btn-secondary mt-3">Back</a>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\StudentController;
 use App\Http\Controllers\SupervisorController;
 use App\Http\Controllers\InstitutionController;
 use App\Http\Controllers\ApplicationController;
+use App\Http\Controllers\InternshipController;
 
 Route::view('/', 'home');
 Route::view('/dashboard', 'home');
@@ -18,7 +19,15 @@ Route::prefix('application')->group(function () {
     Route::put('{id}', [ApplicationController::class, 'update']);
     Route::delete('{id}', [ApplicationController::class, 'destroy']);
 });
-Route::view('/internship', 'internship');
+Route::prefix('internship')->group(function () {
+    Route::get('/', [InternshipController::class, 'index']);
+    Route::get('/add', [InternshipController::class, 'create']);
+    Route::post('/', [InternshipController::class, 'store']);
+    Route::get('{id}/see', [InternshipController::class, 'show']);
+    Route::get('{id}/edit', [InternshipController::class, 'edit']);
+    Route::put('{id}', [InternshipController::class, 'update']);
+    Route::delete('{id}', [InternshipController::class, 'destroy']);
+});
 Route::view('/monitor', 'monitor');
 
 Route::prefix('student')->group(function () {


### PR DESCRIPTION
## Summary
- add Internship model and controller for CRUD operations
- create internship details database view and Blade templates
- wire up internship routes and validation

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e6afc7e083319fdef5b7fdb5b3fd