### PR TITLE
Add monitoring log module with CRUD and views

### DIFF
--- a/app/Http/Controllers/MetaController.php
+++ b/app/Http/Controllers/MetaController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class MetaController extends Controller
+{
+    public function monitorTypes()
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'pgsql') {
+            $types = collect(DB::select("SELECT unnest(enum_range(NULL::monitor_type_enum)) AS type"))->pluck('type');
+        } else {
+            $types = collect(['weekly','issue','final','other']);
+        }
+        return response()->json($types);
+    }
+
+    public function supervisors(Request $request)
+    {
+        $query = DB::table('supervisor_details_view')->select('id','name')->orderBy('name');
+        if ($request->filled('internship_id')) {
+            $query->join('internship_supervisors','supervisor_details_view.id','=','internship_supervisors.supervisor_id')
+                  ->where('internship_supervisors.internship_id', $request->internship_id);
+        }
+        $supervisors = $query->get();
+        if ($supervisors->isEmpty()) {
+            $supervisors = DB::table('supervisor_details_view')->select('id','name')->orderBy('name')->get();
+        }
+        return response()->json($supervisors);
+    }
+}

--- a/app/Http/Controllers/MonitoringLogController.php
+++ b/app/Http/Controllers/MonitoringLogController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MonitoringLog;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class MonitoringLogController extends Controller
+{
+    private function typeOptions(): array
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'pgsql') {
+            return collect(DB::select("SELECT unnest(enum_range(NULL::monitor_type_enum)) AS type"))->pluck('type')->all();
+        }
+        return ['weekly','issue','final','other'];
+    }
+
+    private function supervisorOptions()
+    {
+        return DB::table('supervisor_details_view')->select('id','name')->orderBy('name')->get();
+    }
+
+    public function index()
+    {
+        $logs = DB::table('v_monitoring_log_summary')
+            ->select('monitoring_log_id as id','log_date','student_name','institution_name','supervisor_name','log_type','score','title','content')
+            ->orderByDesc('log_date')
+            ->orderByDesc('id')
+            ->get();
+        return view('monitoring.index', compact('logs'));
+    }
+
+    public function show($id)
+    {
+        $log = DB::table('v_monitoring_log_detail')->where('monitoring_log_id', $id)->first();
+        abort_if(!$log, 404);
+        return view('monitoring.show', compact('log'));
+    }
+
+    public function create()
+    {
+        $internships = DB::table('internship_details_view')
+            ->select('id','student_name','institution_name')
+            ->orderBy('student_name')
+            ->get();
+        $supervisors = $this->supervisorOptions();
+        $types = $this->typeOptions();
+        return view('monitoring.create', compact('internships','supervisors','types'));
+    }
+
+    public function store(Request $request)
+    {
+        $types = $this->typeOptions();
+        $data = $request->validate([
+            'internship_id' => 'required|exists:internships,id',
+            'log_date' => 'required|date',
+            'supervisor_id' => 'nullable|exists:supervisors,id',
+            'type' => 'required|in:' . implode(',', $types),
+            'score' => 'nullable|integer|min:0|max:100',
+            'title' => 'nullable|string|max:150',
+            'content' => 'required|string',
+        ]);
+        MonitoringLog::create($data);
+        return redirect('/monitoring');
+    }
+
+    public function edit($id)
+    {
+        $log = DB::table('v_monitoring_log_detail')->where('monitoring_log_id', $id)->first();
+        abort_if(!$log, 404);
+        $internships = collect([(object)[
+            'id' => $log->internship_id,
+            'student_name' => $log->student_name,
+            'institution_name' => $log->institution_name,
+        ]]);
+        $supervisors = $this->supervisorOptions();
+        $types = $this->typeOptions();
+        return view('monitoring.edit', compact('log','internships','supervisors','types'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $log = MonitoringLog::findOrFail($id);
+        $types = $this->typeOptions();
+        $data = $request->validate([
+            'internship_id' => 'required|exists:internships,id',
+            'log_date' => 'required|date',
+            'supervisor_id' => 'nullable|exists:supervisors,id',
+            'type' => 'required|in:' . implode(',', $types),
+            'score' => 'nullable|integer|min:0|max:100',
+            'title' => 'nullable|string|max:150',
+            'content' => 'required|string',
+        ]);
+        $log->update($data);
+        return redirect('/monitoring');
+    }
+
+    public function destroy($id)
+    {
+        $log = MonitoringLog::findOrFail($id);
+        $log->delete();
+        return redirect('/monitoring');
+    }
+}

--- a/app/Models/MonitoringLog.php
+++ b/app/Models/MonitoringLog.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MonitoringLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'internship_id',
+        'supervisor_id',
+        'log_date',
+        'score',
+        'title',
+        'content',
+        'type',
+    ];
+
+    protected $casts = [
+        'log_date' => 'date',
+    ];
+}

--- a/database/migrations/2024_01_01_000009_create_monitoring_log_views.php
+++ b/database/migrations/2024_01_01_000009_create_monitoring_log_views.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW v_monitoring_log_summary AS
+            SELECT
+              ml.id                    AS monitoring_log_id,
+              ml.log_date,
+              ml.type                  AS log_type,
+              ml.score,
+              COALESCE(ml.title, NULL) AS title,
+              ml.content,
+              it.id                    AS internship_id,
+              u.name                   AS student_name,
+              inst.name                AS institution_name,
+              usv.name                 AS supervisor_name,
+              p.year                   AS period_year,
+              p.term                   AS period_term,
+              it.status                AS internship_status
+            FROM monitoring_logs ml
+            JOIN internships it       ON it.id = ml.internship_id
+            JOIN students s           ON s.id = it.student_id
+            JOIN users u              ON u.id = s.user_id
+            JOIN institutions inst    ON inst.id = it.institution_id
+            JOIN periods p            ON p.id = it.period_id
+            LEFT JOIN supervisors sv  ON sv.id = ml.supervisor_id
+            LEFT JOIN users usv       ON usv.id = sv.user_id;
+        SQL);
+
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW v_monitoring_log_detail AS
+            SELECT
+              ml.id            AS monitoring_log_id,
+              ml.log_date,
+              ml.type          AS log_type,
+              ml.score,
+              ml.title,
+              ml.content,
+              it.id            AS internship_id,
+              it.status        AS internship_status,
+              it.start_date,
+              it.end_date,
+              u.name           AS student_name,
+              inst.name        AS institution_name,
+              p.year           AS period_year,
+              p.term           AS period_term,
+              usv.name         AS supervisor_name
+            FROM monitoring_logs ml
+            JOIN internships it       ON it.id = ml.internship_id
+            JOIN students s           ON s.id = it.student_id
+            JOIN users u              ON u.id = s.user_id
+            JOIN institutions inst    ON inst.id = it.institution_id
+            JOIN periods p            ON p.id = it.period_id
+            LEFT JOIN supervisors sv  ON sv.id = ml.supervisor_id
+            LEFT JOIN users usv       ON usv.id = sv.user_id;
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS v_monitoring_log_detail;');
+        DB::statement('DROP VIEW IF EXISTS v_monitoring_log_summary;');
+    }
+};

--- a/resources/views/monitoring/create.blade.php
+++ b/resources/views/monitoring/create.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('title', 'Add Monitoring Log')
+
+@section('content')
+<h1>Add Monitoring Log</h1>
+@include('monitoring.form', [
+    'action' => '/monitoring',
+    'method' => 'POST',
+    'log' => null,
+    'internships' => $internships,
+    'supervisors' => $supervisors,
+    'types' => $types,
+    'readonly' => false,
+])
+@endsection

--- a/resources/views/monitoring/edit.blade.php
+++ b/resources/views/monitoring/edit.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Monitoring Log')
+
+@section('content')
+<h1>Edit Monitoring Log</h1>
+@include('monitoring.form', [
+    'action' => '/monitoring/' . $log->monitoring_log_id,
+    'method' => 'PUT',
+    'log' => $log,
+    'internships' => $internships,
+    'supervisors' => $supervisors,
+    'types' => $types,
+    'readonly' => true,
+])
+@endsection

--- a/resources/views/monitoring/form.blade.php
+++ b/resources/views/monitoring/form.blade.php
@@ -1,0 +1,62 @@
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if($method === 'PUT')
+        @method('PUT')
+    @endif
+
+    @include('components.form-errors')
+
+    <div class="mb-3">
+        <label class="form-label">Internship</label>
+        <select name="internship_id" class="form-select" {{ $readonly ? 'disabled' : '' }}>
+            @foreach($internships as $internship)
+                <option value="{{ $internship->id }}" {{ old('internship_id', optional($log)->internship_id) == $internship->id ? 'selected' : '' }}>{{ $internship->student_name }} – {{ $internship->institution_name }}</option>
+            @endforeach
+        </select>
+        @if($readonly)
+            <input type="hidden" name="internship_id" value="{{ old('internship_id', optional($log)->internship_id) }}">
+        @endif
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Tanggal</label>
+        <input type="date" name="log_date" class="form-control" value="{{ old('log_date', optional($log)->log_date ? \Illuminate\Support\Carbon::parse($log->log_date)->format('Y-m-d') : '') }}">
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Supervisor</label>
+        <select name="supervisor_id" class="form-select">
+            <option value="">—</option>
+            @foreach($supervisors as $supervisor)
+                <option value="{{ $supervisor->id }}" {{ old('supervisor_id', optional($log)->supervisor_id) == $supervisor->id ? 'selected' : '' }}>{{ $supervisor->name }}</option>
+            @endforeach
+        </select>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Tipe</label>
+        <select name="type" class="form-select">
+            @foreach($types as $type)
+                <option value="{{ $type }}" {{ old('type', optional($log)->log_type ?? optional($log)->type) == $type ? 'selected' : '' }}>{{ $type }}</option>
+            @endforeach
+        </select>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Skor</label>
+        <input type="number" name="score" class="form-control" value="{{ old('score', optional($log)->score) }}" min="0" max="100">
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Judul</label>
+        <input type="text" name="title" class="form-control" value="{{ old('title', optional($log)->title) }}" maxlength="150">
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Isi Laporan</label>
+        <textarea name="content" class="form-control" rows="5" required>{{ old('content', optional($log)->content) }}</textarea>
+    </div>
+
+    <a href="/monitoring" class="btn btn-secondary">Back</a>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/resources/views/monitoring/index.blade.php
+++ b/resources/views/monitoring/index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@php use Illuminate\Support\Str; @endphp
+
+@section('title', 'Monitoring Logs')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h1>Monitoring Logs</h1>
+    <a href="/monitoring/add" class="btn btn-primary">Add</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Date</th>
+            <th>Student</th>
+            <th>Institution</th>
+            <th>Supervisor</th>
+            <th>Type</th>
+            <th>Score</th>
+            <th>Title</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($logs as $log)
+        <tr>
+            <td>{{ $log->log_date }}</td>
+            <td>{{ $log->student_name }}</td>
+            <td>{{ $log->institution_name }}</td>
+            <td>{{ $log->supervisor_name ?? '—' }}</td>
+            <td>{{ $log->log_type }}</td>
+            <td>{{ $log->score ?? '—' }}</td>
+            <td>{{ $log->title ?? Str::limit($log->content, 20) }}</td>
+            <td>
+                <a href="/monitoring/{{ $log->id }}/see" class="btn btn-sm btn-secondary">View</a>
+                <a href="/monitoring/{{ $log->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                <form action="/monitoring/{{ $log->id }}" method="POST" style="display:inline-block" onsubmit="return confirm('Delete this log?')">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @empty
+        <tr><td colspan="8">No monitoring logs found.</td></tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/resources/views/monitoring/show.blade.php
+++ b/resources/views/monitoring/show.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('title', 'Monitoring Log Detail')
+
+@section('content')
+<h1><a href="/internship/{{ $log->internship_id }}/see">{{ $log->student_name }} – {{ $log->institution_name }}</a></h1>
+<ul class="list-unstyled">
+    <li><strong>Date:</strong> {{ $log->log_date }}</li>
+    <li><strong>Supervisor:</strong> {{ $log->supervisor_name ?? '—' }}</li>
+    <li><strong>Type:</strong> {{ $log->log_type }}</li>
+    <li><strong>Score:</strong> {{ $log->score ?? '—' }}</li>
+    <li><strong>Title:</strong> {{ $log->title ?? '—' }}</li>
+</ul>
+<div class="mb-3">
+    <strong>Isi Laporan:</strong>
+    <pre style="white-space: pre-wrap;">{{ $log->content }}</pre>
+</div>
+<a href="/monitoring/{{ $log->monitoring_log_id }}/edit" class="btn btn-warning">Edit</a>
+<form action="/monitoring/{{ $log->monitoring_log_id }}" method="POST" class="d-inline" onsubmit="return confirm('Delete this log?')">
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger" type="submit">Delete</button>
+</form>
+<a href="/monitoring" class="btn btn-secondary">Back</a>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\SupervisorController;
 use App\Http\Controllers\InstitutionController;
 use App\Http\Controllers\ApplicationController;
 use App\Http\Controllers\InternshipController;
+use App\Http\Controllers\MonitoringLogController;
+use App\Http\Controllers\MetaController;
 
 Route::view('/', 'home');
 Route::view('/dashboard', 'home');
@@ -28,7 +30,21 @@ Route::prefix('internship')->group(function () {
     Route::put('{id}', [InternshipController::class, 'update']);
     Route::delete('{id}', [InternshipController::class, 'destroy']);
 });
-Route::view('/monitor', 'monitor');
+
+Route::prefix('monitoring')->group(function () {
+    Route::get('/', [MonitoringLogController::class, 'index']);
+    Route::get('/add', [MonitoringLogController::class, 'create']);
+    Route::post('/', [MonitoringLogController::class, 'store']);
+    Route::get('{id}/see', [MonitoringLogController::class, 'show']);
+    Route::get('{id}/edit', [MonitoringLogController::class, 'edit']);
+    Route::put('{id}', [MonitoringLogController::class, 'update']);
+    Route::delete('{id}', [MonitoringLogController::class, 'destroy']);
+});
+
+Route::prefix('meta')->group(function () {
+    Route::get('/monitor-types', [MetaController::class, 'monitorTypes']);
+    Route::get('/supervisors', [MetaController::class, 'supervisors']);
+});
 
 Route::prefix('student')->group(function () {
     Route::get('/', [StudentController::class, 'index']);


### PR DESCRIPTION
## Summary
- add SQL views for monitoring log summary and detail
- implement MonitoringLog model, controller, and views
- expose meta APIs for monitor types and supervisors

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b50d4d895c833181a4d13d8dd2b361