### PR TITLE
Use text pagination with fixed 10-item pages

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -73,8 +73,7 @@ class ApplicationController extends Controller
         $sortDir = $sortDir === 'asc' ? 'asc' : 'desc';
         $query->orderBy($sortField, $sortDir)->orderByDesc('id');
 
-        $pageSize = min(max((int)$request->query('page_size', 25), 1), 200);
-        $applications = $query->paginate($pageSize)->withQueryString();
+        $applications = $query->paginate(10)->withQueryString();
 
         return view('application.index', [
             'applications' => $applications,

--- a/app/Http/Controllers/InternshipController.php
+++ b/app/Http/Controllers/InternshipController.php
@@ -72,8 +72,7 @@ class InternshipController extends Controller
         $sortDir = $sortDir === 'asc' ? 'asc' : 'desc';
         $query->orderBy($sortField, $sortDir)->orderByDesc('id');
 
-        $pageSize = min(max((int)$request->query('page_size', 25), 1), 200);
-        $internships = $query->paginate($pageSize)->withQueryString();
+        $internships = $query->paginate(10)->withQueryString();
 
         return view('internship.index', [
             'internships' => $internships,

--- a/app/Http/Controllers/MonitoringLogController.php
+++ b/app/Http/Controllers/MonitoringLogController.php
@@ -73,8 +73,7 @@ class MonitoringLogController extends Controller
         $sortDir = $sortDir === 'asc' ? 'asc' : 'desc';
         $query->orderBy($sortField, $sortDir)->orderByDesc('id');
 
-        $pageSize = min(max((int)$request->query('page_size', 25), 1), 200);
-        $logs = $query->paginate($pageSize)->withQueryString();
+        $logs = $query->paginate(10)->withQueryString();
 
         return view('monitoring.index', [
             'logs' => $logs,

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -83,8 +83,7 @@ class StudentController extends Controller
         $sortDir = $sortDir === 'asc' ? 'asc' : 'desc';
         $query->orderBy($sortField, $sortDir);
 
-        $pageSize = min(max((int)$request->query('page_size', 25), 1), 200);
-        $students = $query->paginate($pageSize)->withQueryString();
+        $students = $query->paginate(10)->withQueryString();
 
         return view('student.index', [
             'students' => $students,

--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -73,8 +73,7 @@ class SupervisorController extends Controller
         $sortDir = $sortDir === 'desc' ? 'desc' : 'asc';
         $query->orderBy($sortField, $sortDir);
 
-        $pageSize = min(max((int)$request->query('page_size', 25), 1), 200);
-        $supervisors = $query->paginate($pageSize)->withQueryString();
+        $supervisors = $query->paginate(10)->withQueryString();
 
         return view('supervisor.index', [
             'supervisors' => $supervisors,

--- a/resources/views/application/index.blade.php
+++ b/resources/views/application/index.blade.php
@@ -12,7 +12,7 @@
             <div class="input-group">
                 <input type="text" name="q" value="{{ request('q') }}" class="form-control" placeholder="Cari…" id="application-search-input" style="min-width:280px">
                 @foreach(request()->query() as $param => $value)
-                    @if($param !== 'q' && $param !== 'page')
+                    @if($param !== 'q' && $param !== 'page' && $param !== 'page_size')
                         <input type="hidden" name="{{ $param }}" value="{{ $value }}">
                     @endif
                 @endforeach
@@ -83,7 +83,23 @@
     </tbody>
 </table>
 
-{{ $applications->links() }}
+<p class="text-muted">Total: {{ $applications->total() }} results</p>
+
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $applications->currentPage() }} of {{ $applications->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($applications->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $applications->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($applications->hasMorePages())
+            <a href="{{ $applications->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="applicationFilter">
     <div class="offcanvas-header">
@@ -94,7 +110,6 @@
         <form method="get" id="application-filter-form">
             <input type="hidden" name="q" value="{{ request('q') }}">
             <input type="hidden" name="sort" value="{{ request('sort') }}">
-            <input type="hidden" name="page_size" value="{{ request('page_size') }}">
             @php($statusValues = [])
             @if(request()->has('status') && str_starts_with(request('status'), 'in:'))
                 @php($statusValues = explode(',', substr(request('status'), 3)))
@@ -156,7 +171,7 @@
     </div>
 </div>
 
-@php($retain = Arr::only(request()->query(), ['q','sort','page_size']))
+@php($retain = Arr::only(request()->query(), ['q','sort']))
 
 <script>
 document.getElementById('application-filter-form').addEventListener('submit', function(){

--- a/resources/views/internship/index.blade.php
+++ b/resources/views/internship/index.blade.php
@@ -12,7 +12,7 @@
             <div class="input-group">
                 <input type="text" name="q" value="{{ request('q') }}" class="form-control" placeholder="Cari…" id="internship-search-input" style="min-width:280px">
                 @foreach(request()->query() as $param => $value)
-                    @if($param !== 'q' && $param !== 'page')
+                    @if($param !== 'q' && $param !== 'page' && $param !== 'page_size')
                         <input type="hidden" name="{{ $param }}" value="{{ $value }}">
                     @endif
                 @endforeach
@@ -83,7 +83,23 @@
     </tbody>
 </table>
 
-{{ $internships->links() }}
+<p class="text-muted">Total: {{ $internships->total() }} results</p>
+
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $internships->currentPage() }} of {{ $internships->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($internships->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $internships->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($internships->hasMorePages())
+            <a href="{{ $internships->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="internshipFilter">
     <div class="offcanvas-header">
@@ -94,7 +110,6 @@
         <form method="get" id="internship-filter-form">
             <input type="hidden" name="q" value="{{ request('q') }}">
             <input type="hidden" name="sort" value="{{ request('sort') }}">
-            <input type="hidden" name="page_size" value="{{ request('page_size') }}">
             @php($statusValues = [])
             @if(request()->has('status') && str_starts_with(request('status'), 'in:'))
                 @php($statusValues = explode(',', substr(request('status'), 3)))
@@ -169,7 +184,7 @@
     </div>
 </div>
 
-@php($retain = Arr::only(request()->query(), ['q','sort','page_size']))
+@php($retain = Arr::only(request()->query(), ['q','sort']))
 
 <script>
 document.getElementById('internship-filter-form').addEventListener('submit', function(){

--- a/resources/views/monitoring/index.blade.php
+++ b/resources/views/monitoring/index.blade.php
@@ -12,7 +12,7 @@
             <div class="input-group">
                 <input type="text" name="q" value="{{ request('q') }}" class="form-control" placeholder="Cari…" id="monitoring-search-input" style="min-width:280px">
                 @foreach(request()->query() as $param => $value)
-                    @if($param !== 'q' && $param !== 'page')
+                    @if($param !== 'q' && $param !== 'page' && $param !== 'page_size')
                         <input type="hidden" name="{{ $param }}" value="{{ $value }}">
                     @endif
                 @endforeach
@@ -89,7 +89,23 @@
     </tbody>
 </table>
 
-{{ $logs->links() }}
+<p class="text-muted">Total: {{ $logs->total() }} results</p>
+
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $logs->currentPage() }} of {{ $logs->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($logs->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $logs->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($logs->hasMorePages())
+            <a href="{{ $logs->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="monitoringFilter">
     <div class="offcanvas-header">
@@ -100,7 +116,6 @@
         <form method="get" id="monitoring-filter-form">
             <input type="hidden" name="q" value="{{ request('q') }}">
             <input type="hidden" name="sort" value="{{ request('sort') }}">
-            <input type="hidden" name="page_size" value="{{ request('page_size') }}">
             @php($logRange = request('log_date'))
             @php($logStart = $logEnd = '')
             @if($logRange && str_starts_with($logRange, 'range:'))
@@ -148,7 +163,7 @@
     </div>
 </div>
 
-@php($retain = Arr::only(request()->query(), ['q','sort','page_size']))
+@php($retain = Arr::only(request()->query(), ['q','sort']))
 
 <script>
 document.getElementById('monitoring-filter-form').addEventListener('submit', function(){

--- a/resources/views/student/index.blade.php
+++ b/resources/views/student/index.blade.php
@@ -86,7 +86,21 @@
 
 <p class="text-muted">Total: {{ $students->total() }} results</p>
 
-{{ $students->links() }}
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $students->currentPage() }} of {{ $students->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($students->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $students->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($students->hasMorePages())
+            <a href="{{ $students->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="studentFilter">
     <div class="offcanvas-header">

--- a/resources/views/supervisor/index.blade.php
+++ b/resources/views/supervisor/index.blade.php
@@ -82,7 +82,21 @@
 
 <p class="text-muted">Total: {{ $supervisors->total() }} results</p>
 
-{{ $supervisors->links() }}
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $supervisors->currentPage() }} of {{ $supervisors->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($supervisors->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $supervisors->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($supervisors->hasMorePages())
+            <a href="{{ $supervisors->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="supervisorFilter">
     <div class="offcanvas-header">


### PR DESCRIPTION
## Summary
- Limit student, supervisor, application, internship, and monitoring listings to 10 records per page
- Replace icon pagination with text "Back"/"Next" links and page indicators

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b643a499408331925a7005204270c4