### PR TITLE
Implement session-based authentication with multi-step signup

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,97 +2,122 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
 use App\Models\Student;
+use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 
 class AuthController extends Controller
 {
-    public function showLoginForm()
+    public function signup(Request $request)
     {
-        return view('auth.login');
+        $step = session('register.step', 1);
+        $data = session('register.data', []);
+        $extra = session('register.extra', []);
+
+        if ($request->isMethod('post')) {
+            if ($step === 1) {
+                $validated = $request->validate([
+                    'name' => 'required|string',
+                    'email' => 'required|email|unique:users,email',
+                    'password' => 'required|min:8',
+                    'phone' => 'required|numeric',
+                    'role' => 'required|in:student,supervisor,admin,developer',
+                ]);
+
+                session([
+                    'register.step' => 2,
+                    'register.data' => $validated,
+                ]);
+
+                return redirect()->route('signup');
+            }
+
+            $data = session('register.data');
+            if (!$data) {
+                return redirect()->route('signup');
+            }
+
+            if ($request->has('back')) {
+                $extraInput = $request->only(['student_number', 'national_sn', 'major', 'batch', 'photo']);
+                session(['register.step' => 1, 'register.data' => $data, 'register.extra' => $extraInput]);
+                return redirect()->route('signup');
+            }
+
+            if ($data['role'] === 'student') {
+                $validated = $request->validate([
+                    'student_number' => 'required|numeric',
+                    'national_sn' => 'required|numeric',
+                    'major' => 'required|string',
+                    'batch' => 'required|date_format:Y',
+                    'photo' => 'nullable|string',
+                ]);
+            } else {
+                $validated = [];
+            }
+
+            $user = User::create([
+                'name' => $data['name'],
+                'email' => $data['email'],
+                'password' => $data['password'],
+                'phone' => $data['phone'],
+                'role' => $data['role'],
+            ]);
+
+            if ($data['role'] === 'student') {
+                Student::create([
+                    'user_id' => $user->id,
+                    'student_number' => $validated['student_number'],
+                    'national_sn' => $validated['national_sn'],
+                    'major' => $validated['major'],
+                    'batch' => $validated['batch'],
+                    'photo' => $validated['photo'] ?? null,
+                ]);
+            }
+
+            session()->forget('register');
+            session([
+                'user_id' => $user->id,
+                'role' => $user->role,
+            ]);
+
+            return redirect('/');
+        }
+
+        return view('auth.register', ['step' => $step, 'data' => $data, 'extra' => $extra]);
     }
 
     public function login(Request $request)
     {
-        $credentials = $request->validate([
-            'email' => ['required','email'],
-            'password' => ['required'],
-        ]);
+        if ($request->isMethod('post')) {
+            $credentials = $request->validate([
+                'email' => ['required', 'email'],
+                'password' => ['required'],
+            ]);
 
-        if (Auth::attempt($credentials)) {
-            $request->session()->regenerate();
-            return redirect('/');
+            $user = User::where('email', $credentials['email'])->first();
+
+            if ($user && Hash::check($credentials['password'], $user->password)) {
+                session([
+                    'user_id' => $user->id,
+                    'role' => $user->role,
+                ]);
+                $request->session()->regenerate();
+                return redirect('/');
+            }
+
+            return back()->withErrors([
+                'email' => 'The provided credentials do not match our records.',
+            ])->onlyInput('email');
         }
 
-        return back()->withErrors([
-            'email' => 'The provided credentials do not match our records.',
-        ])->onlyInput('email');
+        return view('auth.login');
     }
 
-    public function showRegisterForm(Request $request)
+    public function logout(Request $request)
     {
-        $step = session('register.step', 1);
-        $data = session('register.data', []);
-        return view('auth.register', compact('step','data'));
-    }
-
-    public function handleRegister(Request $request)
-    {
-        $step = session('register.step', 1);
-
-        if ($step === 1) {
-            $validated = $request->validate([
-                'name' => 'required|string',
-                'email' => 'required|email|unique:users,email',
-                'password' => 'required|min:8',
-                'phone' => 'required|numeric',
-                'role' => 'required|in:student,supervisor,admin,developer',
-            ]);
-
-            session(['register.step' => 2, 'register.data' => $validated]);
-            return redirect()->route('register.show');
-        }
-
-        $data = session('register.data');
-        if (!$data) {
-            return redirect()->route('register.show');
-        }
-
-        if ($data['role'] === 'student') {
-            $validated = $request->validate([
-                'student_number' => 'required|numeric',
-                'national_sn' => 'required|numeric',
-                'major' => 'required|string',
-                'batch' => 'required|date_format:Y',
-                'photo' => 'nullable|string',
-            ]);
-        } else {
-            $validated = [];
-        }
-
-        $user = User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'password' => $data['password'],
-            'phone' => $data['phone'],
-            'role' => $data['role'],
-        ]);
-
-        if ($data['role'] === 'student') {
-            Student::create([
-                'user_id' => $user->id,
-                'student_number' => $validated['student_number'],
-                'national_sn' => $validated['national_sn'],
-                'major' => $validated['major'],
-                'batch' => $validated['batch'],
-                'photo' => $validated['photo'] ?? null,
-            ]);
-        }
-
-        session()->forget('register');
-        return redirect()->route('login.show')->with('status', 'Registration successful.');
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/login');
     }
 }
-

--- a/app/Http/Middleware/EnsureAuthenticated.php
+++ b/app/Http/Middleware/EnsureAuthenticated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureAuthenticated
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!session()->has('user_id')) {
+            return redirect('/login');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureRole.php
+++ b/app/Http/Middleware/EnsureRole.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureRole
+{
+    public function handle(Request $request, Closure $next, ...$roles): Response
+    {
+        if (!session()->has('role') || !in_array(session('role'), $roles)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'auth.session' => \App\Http\Middleware\EnsureAuthenticated::class,
+            'role' => \App\Http\Middleware\EnsureRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/session.php
+++ b/config/session.php
@@ -127,10 +127,7 @@ return [
     |
     */
 
-    'cookie' => env(
-        'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel')).'-session'
-    ),
+    'cookie' => env('SESSION_COOKIE', 'laravel_session'),
 
     /*
     |--------------------------------------------------------------------------
@@ -169,7 +166,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -182,7 +179,7 @@ return [
     |
     */
 
-    'http_only' => env('SESSION_HTTP_ONLY', true),
+    'http_only' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -199,7 +196,7 @@ return [
     |
     */
 
-    'same_site' => env('SESSION_SAME_SITE', 'lax'),
+    'same_site' => 'lax',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -16,7 +16,7 @@
         </ul>
     </div>
 @endif
-<form method="POST" action="{{ route('login.perform') }}">
+<form method="POST" action="{{ route('login') }}">
     @csrf
     <div>
         <label>Email</label>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -14,7 +14,7 @@
     </div>
 @endif
 @if ($step === 1)
-<form method="POST" action="{{ route('register.handle') }}">
+<form method="POST" action="{{ route('signup') }}">
     @csrf
     <div>
         <label>Name</label>
@@ -44,30 +44,31 @@
     <button type="submit">Next</button>
 </form>
 @else
-<form method="POST" action="{{ route('register.handle') }}">
+<form method="POST" action="{{ route('signup') }}">
     @csrf
     @if (($data['role'] ?? '') === 'student')
     <div>
         <label>Student Number</label>
-        <input type="number" name="student_number" value="{{ old('student_number') }}" required>
+        <input type="number" name="student_number" value="{{ old('student_number', $extra['student_number'] ?? '') }}" required>
     </div>
     <div>
         <label>National Student Number</label>
-        <input type="number" name="national_sn" value="{{ old('national_sn') }}" required>
+        <input type="number" name="national_sn" value="{{ old('national_sn', $extra['national_sn'] ?? '') }}" required>
     </div>
     <div>
         <label>Major</label>
-        <input type="text" name="major" value="{{ old('major') }}" required>
+        <input type="text" name="major" value="{{ old('major', $extra['major'] ?? '') }}" required>
     </div>
     <div>
         <label>Batch</label>
-        <input type="number" name="batch" value="{{ old('batch') }}" required>
+        <input type="number" name="batch" value="{{ old('batch', $extra['batch'] ?? '') }}" required>
     </div>
     <div>
         <label>Photo (link)</label>
-        <input type="text" name="photo" value="{{ old('photo') }}">
+        <input type="text" name="photo" value="{{ old('photo', $extra['photo'] ?? '') }}">
     </div>
     @endif
+    <button type="submit" name="back" value="1">Back</button>
     <button type="submit">Sign Up</button>
 </form>
 @endif

--- a/resources/views/introduction.blade.php
+++ b/resources/views/introduction.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Introduction</title>
+</head>
+<body>
+    <h1>Introduction</h1>
+    <p>Welcome to the application.</p>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,74 +10,78 @@ use App\Http\Controllers\InternshipController;
 use App\Http\Controllers\MonitoringLogController;
 use App\Http\Controllers\MetaController;
 
-Route::view('/', 'home');
-Route::view('/dashboard', 'home');
-Route::prefix('application')->group(function () {
-    Route::get('/', [ApplicationController::class, 'index']);
-    Route::get('/add', [ApplicationController::class, 'create']);
-    Route::post('/', [ApplicationController::class, 'store']);
-    Route::get('{id}/see', [ApplicationController::class, 'show']);
-    Route::get('{id}/edit', [ApplicationController::class, 'edit']);
-    Route::put('{id}', [ApplicationController::class, 'update']);
-    Route::delete('{id}', [ApplicationController::class, 'destroy']);
-});
-Route::prefix('internship')->group(function () {
-    Route::get('/', [InternshipController::class, 'index']);
-    Route::get('/add', [InternshipController::class, 'create']);
-    Route::post('/', [InternshipController::class, 'store']);
-    Route::get('{id}/see', [InternshipController::class, 'show']);
-    Route::get('{id}/edit', [InternshipController::class, 'edit']);
-    Route::put('{id}', [InternshipController::class, 'update']);
-    Route::delete('{id}', [InternshipController::class, 'destroy']);
-});
+Route::view('/introduction', 'introduction');
 
-Route::prefix('monitoring')->group(function () {
-    Route::get('/', [MonitoringLogController::class, 'index']);
-    Route::get('/add', [MonitoringLogController::class, 'create']);
-    Route::post('/', [MonitoringLogController::class, 'store']);
-    Route::get('{id}/see', [MonitoringLogController::class, 'show']);
-    Route::get('{id}/edit', [MonitoringLogController::class, 'edit']);
-    Route::put('{id}', [MonitoringLogController::class, 'update']);
-    Route::delete('{id}', [MonitoringLogController::class, 'destroy']);
+Route::match(['get', 'post'], '/login', [AuthController::class, 'login'])->name('login');
+Route::match(['get', 'post'], '/signup', [AuthController::class, 'signup'])->name('signup');
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+
+Route::middleware('auth.session')->group(function () {
+    Route::view('/', 'home');
+    Route::view('/dashboard', 'home');
+
+    Route::prefix('application')->group(function () {
+        Route::get('/', [ApplicationController::class, 'index']);
+        Route::get('/add', [ApplicationController::class, 'create']);
+        Route::post('/', [ApplicationController::class, 'store']);
+        Route::get('{id}/see', [ApplicationController::class, 'show']);
+        Route::get('{id}/edit', [ApplicationController::class, 'edit']);
+        Route::put('{id}', [ApplicationController::class, 'update']);
+        Route::delete('{id}', [ApplicationController::class, 'destroy']);
+    });
+
+    Route::prefix('internship')->group(function () {
+        Route::get('/', [InternshipController::class, 'index']);
+        Route::get('/add', [InternshipController::class, 'create']);
+        Route::post('/', [InternshipController::class, 'store']);
+        Route::get('{id}/see', [InternshipController::class, 'show']);
+        Route::get('{id}/edit', [InternshipController::class, 'edit']);
+        Route::put('{id}', [InternshipController::class, 'update']);
+        Route::delete('{id}', [InternshipController::class, 'destroy']);
+    });
+
+    Route::prefix('monitoring')->group(function () {
+        Route::get('/', [MonitoringLogController::class, 'index']);
+        Route::get('/add', [MonitoringLogController::class, 'create']);
+        Route::post('/', [MonitoringLogController::class, 'store']);
+        Route::get('{id}/see', [MonitoringLogController::class, 'show']);
+        Route::get('{id}/edit', [MonitoringLogController::class, 'edit']);
+        Route::put('{id}', [MonitoringLogController::class, 'update']);
+        Route::delete('{id}', [MonitoringLogController::class, 'destroy']);
+    });
+
+    Route::prefix('meta')->group(function () {
+        Route::get('/monitor-types', [MetaController::class, 'monitorTypes']);
+        Route::get('/supervisors', [MetaController::class, 'supervisors']);
+    });
+
+    Route::prefix('student')->group(function () {
+        Route::get('/', [StudentController::class, 'index']);
+        Route::get('/add', [StudentController::class, 'create']);
+        Route::post('/', [StudentController::class, 'store']);
+        Route::get('{id}/see', [StudentController::class, 'show']);
+        Route::get('{id}/edit', [StudentController::class, 'edit']);
+        Route::put('{id}', [StudentController::class, 'update']);
+        Route::delete('{id}', [StudentController::class, 'destroy']);
+    });
+
+    Route::prefix('supervisor')->group(function () {
+        Route::get('/', [SupervisorController::class, 'index']);
+        Route::get('/add', [SupervisorController::class, 'create']);
+        Route::post('/', [SupervisorController::class, 'store']);
+        Route::get('{id}/see', [SupervisorController::class, 'show']);
+        Route::get('{id}/edit', [SupervisorController::class, 'edit']);
+        Route::put('{id}', [SupervisorController::class, 'update']);
+        Route::delete('{id}', [SupervisorController::class, 'destroy']);
+    });
+
+    Route::prefix('institution')->group(function () {
+        Route::get('/', [InstitutionController::class, 'index']);
+        Route::get('/add', [InstitutionController::class, 'create']);
+        Route::post('/', [InstitutionController::class, 'store']);
+        Route::get('{id}/see', [InstitutionController::class, 'show']);
+        Route::get('{id}/edit', [InstitutionController::class, 'edit']);
+        Route::put('{id}', [InstitutionController::class, 'update']);
+        Route::delete('{id}', [InstitutionController::class, 'destroy']);
+    });
 });
-
-Route::prefix('meta')->group(function () {
-    Route::get('/monitor-types', [MetaController::class, 'monitorTypes']);
-    Route::get('/supervisors', [MetaController::class, 'supervisors']);
-});
-
-Route::prefix('student')->group(function () {
-    Route::get('/', [StudentController::class, 'index']);
-    Route::get('/add', [StudentController::class, 'create']);
-    Route::post('/', [StudentController::class, 'store']);
-    Route::get('{id}/see', [StudentController::class, 'show']);
-    Route::get('{id}/edit', [StudentController::class, 'edit']);
-    Route::put('{id}', [StudentController::class, 'update']);
-    Route::delete('{id}', [StudentController::class, 'destroy']);
-});
-
-Route::prefix('supervisor')->group(function () {
-    Route::get('/', [SupervisorController::class, 'index']);
-    Route::get('/add', [SupervisorController::class, 'create']);
-    Route::post('/', [SupervisorController::class, 'store']);
-    Route::get('{id}/see', [SupervisorController::class, 'show']);
-    Route::get('{id}/edit', [SupervisorController::class, 'edit']);
-    Route::put('{id}', [SupervisorController::class, 'update']);
-    Route::delete('{id}', [SupervisorController::class, 'destroy']);
-});
-
-Route::prefix('institution')->group(function () {
-    Route::get('/', [InstitutionController::class, 'index']);
-    Route::get('/add', [InstitutionController::class, 'create']);
-    Route::post('/', [InstitutionController::class, 'store']);
-    Route::get('{id}/see', [InstitutionController::class, 'show']);
-    Route::get('{id}/edit', [InstitutionController::class, 'edit']);
-    Route::put('{id}', [InstitutionController::class, 'update']);
-    Route::delete('{id}', [InstitutionController::class, 'destroy']);
-});
-
-Route::get('auth/login', [AuthController::class, 'showLoginForm'])->name('login.show');
-Route::post('auth/login', [AuthController::class, 'login'])->name('login.perform');
-
-Route::get('auth/register', [AuthController::class, 'showRegisterForm'])->name('register.show');
-Route::post('auth/register', [AuthController::class, 'handleRegister'])->name('register.handle');


### PR DESCRIPTION
## Summary
- Add session-driven signup, login, and logout in `AuthController`
- Introduce `EnsureAuthenticated` and `EnsureRole` middlewares with route aliases
- Expand register view with Back button and session persistence across steps
- Lock down routes behind session auth, leaving `/introduction` public
- Configure secure `laravel_session` cookie

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b6580d7da88331851e9280bf3ddf67