### PR TITLE
Restrict signup roles to student or supervisor

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -36,7 +36,7 @@
         <label>Role</label>
         <select name="role" required>
             <option value="">Select role</option>
-            @foreach (['student','supervisor','admin','developer'] as $role)
+            @foreach (['student','supervisor'] as $role)
                 <option value="{{ $role }}" {{ (old('role', $data['role'] ?? '') === $role) ? 'selected' : '' }}>{{ ucfirst($role) }}</option>
             @endforeach
         </select>
@@ -44,7 +44,7 @@
     <button type="submit">Next</button>
 </form>
 @else
-<form method="POST" action="{{ route('signup') }}">
+<form method="POST" action="{{ route('signup') }}" enctype="multipart/form-data">
     @csrf
     @if (($data['role'] ?? '') === 'student')
     <div>
@@ -66,6 +66,27 @@
     <div>
         <label>Photo (link)</label>
         <input type="text" name="photo" value="{{ old('photo', $extra['photo'] ?? '') }}">
+    </div>
+    @elseif (($data['role'] ?? '') === 'supervisor')
+    <div>
+        <label>Supervisor Number</label>
+        <input type="text" name="supervisor_number" value="{{ old('supervisor_number', $extra['supervisor_number'] ?? '') }}" required>
+    </div>
+    <div>
+        <label>Department</label>
+        <select name="department" required>
+            <option value="">Select department</option>
+            @foreach ($departments as $dept)
+                <option value="{{ $dept }}" {{ (old('department', $extra['department'] ?? '') === $dept) ? 'selected' : '' }}>{{ $dept }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Photo</label>
+        <input type="file" name="photo" {{ empty($extra['photo']) ? 'required' : '' }}>
+        @if (!empty($extra['photo']))
+            <p>Photo uploaded.</p>
+        @endif
     </div>
     @endif
     <button type="submit" name="back" value="1">Back</button>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
## Summary
- Limit signup role selector and validation to student and supervisor
- Add supervisor-specific fields and validation with session persistence
- Adjust feature test for login redirect

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b798315ad48331abb3180711b7cee3