### PR TITLE
Allow text entry for supervisor department

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -10,8 +10,6 @@ use Illuminate\Support\Facades\Hash;
 
 class AuthController extends Controller
 {
-    private const DEPARTMENTS = ['Engineering', 'Business', 'Design'];
-
     public function signup(Request $request)
     {
         $step = session('register.step', 1);
@@ -63,7 +61,7 @@ class AuthController extends Controller
             } else {
                 $validated = $request->validate([
                     'supervisor_number' => 'required|string|max:64|regex:/^[A-Za-z0-9_-]+$/',
-                    'department' => 'required|in:' . implode(',', self::DEPARTMENTS),
+                    'department' => 'required|string',
                     'photo' => 'required|url',
 
                 ]);
@@ -92,7 +90,6 @@ class AuthController extends Controller
                     'supervisor_number' => $validated['supervisor_number'],
                     'department' => $validated['department'],
                     'photo' => $validated['photo'],
-                    'photo' => $photoPath,
                 ]);
             }
 
@@ -105,7 +102,7 @@ class AuthController extends Controller
             return redirect('/');
         }
 
-        return view('auth.register', ['step' => $step, 'data' => $data, 'extra' => $extra, 'departments' => self::DEPARTMENTS]);
+        return view('auth.register', ['step' => $step, 'data' => $data, 'extra' => $extra]);
     }
 
     public function login(Request $request)

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -74,19 +74,14 @@
     </div>
     <div>
         <label>Department</label>
-        <select name="department" required>
-            <option value="">Select department</option>
-            @foreach ($departments as $dept)
-                <option value="{{ $dept }}" {{ (old('department', $extra['department'] ?? '') === $dept) ? 'selected' : '' }}>{{ $dept }}</option>
-            @endforeach
-        </select>
+        <input type="text" name="department" value="{{ old('department', $extra['department'] ?? '') }}" required>
     </div>
     <div>
         <label>Photo (link)</label>
         <input type="text" name="photo" value="{{ old('photo', $extra['photo'] ?? '') }}" required>
     </div>
     @endif
-    <button type="submit" name="back" value="1">Back</button>
+    <button type="submit" name="back" value="1" formnovalidate>Back</button>
     <button type="submit">Sign Up</button>
 </form>
 @endif


### PR DESCRIPTION
## Summary
- Change supervisor department field on signup to a text input
- Skip validation when using the back button in signup flow
- Simplify supervisor signup validation and fix photo assignment

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b7a083b0d883319aee69f3414ba16a