### PR TITLE
Restrict supervisors to own profile

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -13,5 +13,13 @@ abstract class Controller
         }
         return DB::table('students')->where('user_id', session('user_id'))->value('id');
     }
+
+    protected function currentSupervisorId(): ?int
+    {
+        if (session('role') !== 'supervisor') {
+            return null;
+        }
+        return DB::table('supervisors')->where('user_id', session('user_id'))->value('id');
+    }
 }
 

--- a/app/Http/Middleware/EnsureSupervisorSelf.php
+++ b/app/Http/Middleware/EnsureSupervisorSelf.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureSupervisorSelf
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (session('role') === 'supervisor') {
+            $supervisorId = DB::table('supervisors')->where('user_id', session('user_id'))->value('id');
+            $routeId = (int) $request->route('id');
+            if ($routeId !== $supervisorId) {
+                abort(401);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'auth.session' => \App\Http\Middleware\EnsureAuthenticated::class,
             'role' => \App\Http\Middleware\EnsureRole::class,
+            'supervisor.self' => \App\Http\Middleware\EnsureSupervisorSelf::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/views/supervisor/index.blade.php
+++ b/resources/views/supervisor/index.blade.php
@@ -6,6 +6,7 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Supervisors</h1>
     @php($isStudent = session('role') === 'student')
+    @php($isSupervisor = session('role') === 'supervisor')
     <div class="d-flex align-items-center gap-2">
         <form method="get" action="{{ url()->current() }}" id="supervisor-search-form" class="position-relative">
             <div class="input-group" style="min-width:280px;">
@@ -26,7 +27,7 @@
             <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary">{{ count($filters) }}</span>
             @endif
         </button>
-        @if($isStudent)
+        @if($isStudent || $isSupervisor)
             <button class="btn btn-primary" disabled>Add</button>
         @else
             <a href="/supervisor/add" class="btn btn-primary">Add</a>
@@ -63,7 +64,7 @@
             <td>{{ $supervisor->department }}</td>
             <td>
                 <a href="/supervisor/{{ $supervisor->id }}/see" class="btn btn-sm btn-secondary">View</a>
-                @if($isStudent)
+                @if($isStudent || ($isSupervisor && $supervisor->id !== $currentSupervisorId))
                     <button class="btn btn-sm btn-warning" disabled>Edit</button>
                     <button class="btn btn-sm btn-danger" disabled>Delete</button>
                 @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,12 +67,16 @@ Route::middleware('auth.session')->group(function () {
 
     Route::prefix('supervisor')->group(function () {
         Route::get('/', [SupervisorController::class, 'index']);
-        Route::get('/add', [SupervisorController::class, 'create']);
-        Route::post('/', [SupervisorController::class, 'store']);
-        Route::get('{id}/see', [SupervisorController::class, 'show']);
-        Route::get('{id}/edit', [SupervisorController::class, 'edit']);
-        Route::put('{id}', [SupervisorController::class, 'update']);
-        Route::delete('{id}', [SupervisorController::class, 'destroy']);
+        Route::middleware('role:admin')->group(function () {
+            Route::get('/add', [SupervisorController::class, 'create']);
+            Route::post('/', [SupervisorController::class, 'store']);
+        });
+        Route::middleware('supervisor.self')->group(function () {
+            Route::get('{id}/see', [SupervisorController::class, 'show']);
+            Route::get('{id}/edit', [SupervisorController::class, 'edit']);
+            Route::put('{id}', [SupervisorController::class, 'update']);
+            Route::delete('{id}', [SupervisorController::class, 'destroy']);
+        });
     });
 
     Route::prefix('institution')->group(function () {


### PR DESCRIPTION
## Summary
- Scope supervisor CRUD to their own record
- Block supervisor creation to admins only
- Enforce supervisor self-access via dedicated middleware

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b7be94ab888331942d22288025fa84