### PR TITLE
Allow developers to manage admin accounts

### DIFF
--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -109,7 +109,7 @@ class SupervisorController extends Controller
 
     public function create()
     {
-        if (session('role') !== 'admin') {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
             abort(401);
         }
         return view('supervisor.create');
@@ -117,7 +117,7 @@ class SupervisorController extends Controller
 
     public function store(Request $request)
     {
-        if (session('role') !== 'admin') {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
             abort(401);
         }
         $data = $request->validate([

--- a/app/Http/Middleware/EnsureAdmin.php
+++ b/app/Http/Middleware/EnsureAdmin.php
@@ -10,7 +10,7 @@ class EnsureAdmin
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if (session('role') !== 'admin') {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
             abort(401);
         }
         return $next($request);

--- a/app/Http/Middleware/EnsureAdminSelf.php
+++ b/app/Http/Middleware/EnsureAdminSelf.php
@@ -15,6 +15,8 @@ class EnsureAdminSelf
             if ($routeId !== (int) session('user_id')) {
                 abort(401);
             }
+        } elseif (session('role') === 'developer') {
+            // Developers can manage any admin account
         } else {
             abort(401);
         }

--- a/resources/views/admin/create.blade.php
+++ b/resources/views/admin/create.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Add Admin')
+
+@section('content')
+<h1>Add Admin</h1>
+@include('admin.form', ['action' => '/admin', 'method' => 'POST', 'admin' => null])
+@endsection

--- a/resources/views/admin/form.blade.php
+++ b/resources/views/admin/form.blade.php
@@ -19,7 +19,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Role</label>
-        <input type="text" class="form-control" value="{{ old('role', optional($admin)->role) }}" readonly>
+        <input type="text" class="form-control" value="{{ old('role', optional($admin)->role ?? 'admin') }}" readonly>
     </div>
     <div class="mb-3">
         <label class="form-label">Password</label>

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -16,7 +16,11 @@
                 <div class="spinner-border spinner-border-sm text-secondary"></div>
             </div>
         </form>
+        @if(session('role') === 'developer')
+        <a class="btn btn-primary" href="/admin/add">Add</a>
+        @else
         <button class="btn btn-primary" disabled>Add</button>
+        @endif
     </div>
 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,7 +68,7 @@ Route::middleware('auth.session')->group(function () {
 
     Route::prefix('supervisor')->group(function () {
         Route::get('/', [SupervisorController::class, 'index']);
-        Route::middleware('role:admin')->group(function () {
+        Route::middleware('role:admin,developer')->group(function () {
             Route::get('/add', [SupervisorController::class, 'create']);
             Route::post('/', [SupervisorController::class, 'store']);
         });


### PR DESCRIPTION
## Summary
- Let `developer` role pass admin middleware checks
- Expand supervisor and admin management so developers can CRUD admin users
- Update admin views with add page and default role handling

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c70d0bd88331a0a5ce5aff037fe1