### PR TITLE
Enable student self-management and session validation

### DIFF
--- a/app/Http/Middleware/EnsureAuthenticated.php
+++ b/app/Http/Middleware/EnsureAuthenticated.php
@@ -14,6 +14,13 @@ class EnsureAuthenticated
             return redirect('/login');
         }
 
+        $exists = \Illuminate\Support\Facades\DB::table('users')->where('id', session('user_id'))->exists();
+        if (!$exists) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+            return redirect('/login')->with('status', 'Akun Anda tidak ditemukan. Kemungkinan telah dihapus.');
+        }
+
         return $next($request);
     }
 }

--- a/app/Http/Middleware/EnsureStudentSelf.php
+++ b/app/Http/Middleware/EnsureStudentSelf.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureStudentSelf
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (session('role') === 'student') {
+            $studentId = DB::table('students')->where('user_id', session('user_id'))->value('id');
+            $routeId = (int) $request->route('id');
+            if ($routeId !== (int) $studentId) {
+                abort(401);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'supervisor.self' => \App\Http\Middleware\EnsureSupervisorSelf::class,
             'admin' => \App\Http\Middleware\EnsureAdmin::class,
             'admin.self' => \App\Http\Middleware\EnsureAdminSelf::class,
+            'student.self' => \App\Http\Middleware\EnsureStudentSelf::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,6 +23,9 @@
         </div>
     </nav>
     <main class="p-4 flex-fill">
+        @if (session('status'))
+            <div class="alert alert-info">{{ session('status') }}</div>
+        @endif
         @yield('content')
     </main>
 </div>

--- a/resources/views/student/index.blade.php
+++ b/resources/views/student/index.blade.php
@@ -68,8 +68,12 @@
             <td>
                 <a href="/student/{{ $student->id }}/see" class="btn btn-sm btn-secondary">View</a>
                 @if($isStudent)
-                    <button class="btn btn-sm btn-warning" disabled>Edit</button>
-                    <button class="btn btn-sm btn-danger" disabled>Delete</button>
+                    <a href="/student/{{ $student->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                    <form action="/student/{{ $student->id }}" method="POST" style="display:inline-block">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                    </form>
                 @else
                     <a href="/student/{{ $student->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
                     <form action="/student/{{ $student->id }}" method="POST" style="display:inline-block">

--- a/resources/views/student/show.blade.php
+++ b/resources/views/student/show.blade.php
@@ -27,5 +27,23 @@
         </ul>
     </div>
 </div>
-<a href="/student" class="btn btn-secondary mt-3">Back</a>
+@php($isStudent = session('role') === 'student')
+<div class="mt-3">
+    <a href="/student" class="btn btn-secondary">Back</a>
+    @if($isStudent)
+        <a href="/student/{{ $student->id }}/edit" class="btn btn-warning">Edit</a>
+        <form action="/student/{{ $student->id }}" method="POST" style="display:inline-block">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    @else
+        <a href="/student/{{ $student->id }}/edit" class="btn btn-warning">Edit</a>
+        <form action="/student/{{ $student->id }}" method="POST" style="display:inline-block">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    @endif
+</div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,10 +60,12 @@ Route::middleware('auth.session')->group(function () {
         Route::get('/', [StudentController::class, 'index']);
         Route::get('/add', [StudentController::class, 'create']);
         Route::post('/', [StudentController::class, 'store']);
-        Route::get('{id}/see', [StudentController::class, 'show']);
-        Route::get('{id}/edit', [StudentController::class, 'edit']);
-        Route::put('{id}', [StudentController::class, 'update']);
-        Route::delete('{id}', [StudentController::class, 'destroy']);
+        Route::middleware('student.self')->group(function () {
+            Route::get('{id}/see', [StudentController::class, 'show']);
+            Route::get('{id}/edit', [StudentController::class, 'edit']);
+            Route::put('{id}', [StudentController::class, 'update']);
+            Route::delete('{id}', [StudentController::class, 'destroy']);
+        });
     });
 
     Route::prefix('supervisor')->group(function () {


### PR DESCRIPTION
## Summary
- Allow students to edit and delete only their own profile with flash messages
- Add middleware and auth checks to restrict student actions and validate sessions
- Surface status notifications in layout and expose edit/delete buttons for students

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ca710e148331b36ba9294837edee