### PR TITLE
feat: add developer management

### DIFF
--- a/app/Http/Controllers/DeveloperController.php
+++ b/app/Http/Controllers/DeveloperController.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class DeveloperController extends Controller
+{
+    /**
+     * Columns searched and displayed. Adjust here if needed.
+     */
+    private const SEARCH_COLUMNS = ['name', 'email', 'role'];
+    private const DISPLAY_COLUMNS = ['id', 'name', 'email', 'role'];
+
+    public function index(Request $request)
+    {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
+            abort(401);
+        }
+
+        $query = DB::table('users')
+            ->select('id', 'name', 'email', 'role', 'created_at', 'updated_at')
+            ->where('role', 'developer');
+        if (session('role') === 'developer') {
+            $query->where('id', session('user_id'));
+        }
+
+        $filters = [];
+
+        if ($created = $request->query('created_at')) {
+            if (Str::startsWith($created, 'range:')) {
+                [$start, $end] = array_pad(explode(',', Str::after($created, 'range:')), 2, null);
+                if ($start) {
+                    $query->whereDate('created_at', '>=', $start);
+                }
+                if ($end) {
+                    $query->whereDate('created_at', '<=', $end);
+                }
+                $filters['created_at'] = 'Created: ' . $start . ' - ' . $end;
+            }
+        }
+
+        if ($updated = $request->query('updated_at')) {
+            if (Str::startsWith($updated, 'range:')) {
+                [$start, $end] = array_pad(explode(',', Str::after($updated, 'range:')), 2, null);
+                if ($start) {
+                    $query->whereDate('updated_at', '>=', $start);
+                }
+                if ($end) {
+                    $query->whereDate('updated_at', '<=', $end);
+                }
+                $filters['updated_at'] = 'Updated: ' . $start . ' - ' . $end;
+            }
+        }
+
+        if ($q = trim($request->query('q', ''))) {
+            $qLower = strtolower($q);
+            $query->where(function ($sub) use ($qLower) {
+                foreach (self::SEARCH_COLUMNS as $col) {
+                    $sub->orWhereRaw('LOWER(' . $col . ') LIKE ?', ['%' . $qLower . '%']);
+                }
+            });
+        }
+
+        $sort = $request->query('sort', 'created_at:desc');
+        [$sortField, $sortDir] = array_pad(explode(':', $sort), 2, 'desc');
+        $allowedSorts = array_merge(self::DISPLAY_COLUMNS, ['created_at', 'updated_at']);
+        if (!in_array($sortField, $allowedSorts)) {
+            $sortField = 'created_at';
+        }
+        $sortDir = $sortDir === 'asc' ? 'asc' : 'desc';
+        $query->orderBy($sortField, $sortDir);
+
+        $developers = $query->paginate(10)->withQueryString();
+
+        return view('developer.index', [
+            'developers' => $developers,
+            'filters' => $filters,
+        ]);
+    }
+
+    public function show($id)
+    {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
+            abort(401);
+        }
+        $developer = User::where('role', 'developer')->findOrFail($id);
+        if (session('role') === 'developer' && $developer->id !== session('user_id')) {
+            abort(401);
+        }
+        return view('developer.show', compact('developer'));
+    }
+
+    public function create()
+    {
+        if (session('role') !== 'admin') {
+            abort(401);
+        }
+        return view('developer.create');
+    }
+
+    public function store(Request $request)
+    {
+        if (session('role') !== 'admin') {
+            abort(401);
+        }
+        $data = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email',
+            'phone' => 'nullable|string',
+            'password' => 'required|string',
+        ]);
+
+        User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'phone' => $data['phone'] ?? null,
+            'password' => Hash::make($data['password']),
+            'role' => 'developer',
+        ]);
+
+        return redirect('/developer')->with('status', 'Developer created.');
+    }
+
+    public function edit($id)
+    {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
+            abort(401);
+        }
+        if (session('role') === 'developer' && (int) $id !== session('user_id')) {
+            abort(401);
+        }
+        $developer = User::where('role', 'developer')->findOrFail($id);
+        return view('developer.edit', compact('developer'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        if (!in_array(session('role'), ['admin', 'developer'])) {
+            abort(401);
+        }
+        if (session('role') === 'developer' && (int) $id !== session('user_id')) {
+            abort(401);
+        }
+        $developer = User::where('role', 'developer')->findOrFail($id);
+
+        $data = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email,' . $developer->id,
+            'phone' => 'nullable|string',
+            'password' => 'nullable|string',
+        ]);
+
+        $developer->name = $data['name'];
+        $developer->email = $data['email'];
+        $developer->phone = $data['phone'] ?? null;
+        if (!empty($data['password'])) {
+            $developer->password = Hash::make($data['password']);
+        }
+        $developer->save();
+
+        $message = session('role') === 'developer' ? 'Profil berhasil diperbarui.' : 'Developer updated.';
+        return redirect('/developer')->with('status', $message);
+    }
+
+    public function destroy($id)
+    {
+        if (session('role') !== 'admin') {
+            abort(401);
+        }
+        $developer = User::where('role', 'developer')->findOrFail($id);
+        $developer->delete();
+        return redirect('/developer')->with('status', 'Developer deleted.');
+    }
+}

--- a/app/Http/Middleware/EnsureDeveloperSelf.php
+++ b/app/Http/Middleware/EnsureDeveloperSelf.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureDeveloperSelf
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (session('role') === 'developer') {
+            $routeId = (int) $request->route('id');
+            if ($routeId !== (int) session('user_id')) {
+                abort(401);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => \App\Http\Middleware\EnsureAdmin::class,
             'admin.self' => \App\Http\Middleware\EnsureAdminSelf::class,
             'student.self' => \App\Http\Middleware\EnsureStudentSelf::class,
+            'developer.self' => \App\Http\Middleware\EnsureDeveloperSelf::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/views/developer/create.blade.php
+++ b/resources/views/developer/create.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Add Developer')
+
+@section('content')
+<h1>Add Developer</h1>
+@include('developer.form', ['action' => '/developer', 'method' => 'POST', 'developer' => null])
+@endsection

--- a/resources/views/developer/edit.blade.php
+++ b/resources/views/developer/edit.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Developer')
+
+@section('content')
+<h1>Edit Developer</h1>
+@include('developer.form', ['action' => "/developer/{$developer->id}", 'method' => 'PUT', 'developer' => $developer])
+@endsection

--- a/resources/views/developer/form.blade.php
+++ b/resources/views/developer/form.blade.php
@@ -1,0 +1,27 @@
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if($method === 'PUT')
+        @method('PUT')
+    @endif
+
+    @include('components.form-errors')
+
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', optional($developer)->name) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ old('email', optional($developer)->email) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ old('phone', optional($developer)->phone) }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control">
+    </div>
+    <a href="/developer" class="btn btn-secondary">Back</a>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/resources/views/developer/index.blade.php
+++ b/resources/views/developer/index.blade.php
@@ -1,0 +1,124 @@
+@extends('layouts.app')
+
+@section('title', 'Developers')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Developers</h1>
+    <div class="d-flex align-items-center gap-2">
+        <form method="get" action="{{ url()->current() }}" id="developer-search-form" class="position-relative">
+            <div class="input-group" style="min-width:280px;">
+                <input type="search" name="q" id="developer-search-input" class="form-control" placeholder="Cari…" aria-label="Search" value="{{ request('q') }}">
+                <button class="btn btn-outline-secondary" type="submit" id="developer-search-submit"><i class="bi bi-search"></i></button>
+                <button class="btn btn-outline-secondary" type="button" id="developer-search-clear" @if(!request('q')) style="display:none;" @endif><i class="bi bi-x"></i></button>
+            </div>
+            <div id="developer-search-spinner" class="position-absolute top-50 end-0 translate-middle-y me-2 d-none">
+                <div class="spinner-border spinner-border-sm text-secondary"></div>
+            </div>
+        </form>
+        @if(session('role') === 'admin')
+            <a href="/developer/add" class="btn btn-primary">Add</a>
+        @else
+            <button class="btn btn-primary" disabled>Add</button>
+        @endif
+    </div>
+</div>
+
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>No</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($developers as $developer)
+        <tr>
+            <td>{{ $developers->total() - ($developers->currentPage() - 1) * $developers->perPage() - $loop->index }}</td>
+            <td>{{ $developer->name }}</td>
+            <td>{{ $developer->email }}</td>
+            <td>
+                <a href="/developer/{{ $developer->id }}/see" class="btn btn-sm btn-secondary">View</a>
+                @if(session('role') === 'admin' || session('user_id') == $developer->id)
+                    <a href="/developer/{{ $developer->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                @else
+                    <button class="btn btn-sm btn-warning" disabled>Edit</button>
+                @endif
+                @if(session('role') === 'admin')
+                    <form action="/developer/{{ $developer->id }}" method="POST" style="display:inline-block">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                    </form>
+                @else
+                    <button class="btn btn-sm btn-danger" disabled>Delete</button>
+                @endif
+            </td>
+        </tr>
+        @empty
+        <tr>
+            <td colspan="4" class="text-center">
+                @if(request('q'))
+                    Tidak ada hasil untuk '{{ request('q') }}'.
+                @else
+                    No developers found.
+                @endif
+            </td>
+        </tr>
+        @endforelse
+    </tbody>
+</table>
+
+<p class="text-muted">Showing {{ $developers->count() }} out of {{ $developers->total() }} developers</p>
+
+<div class="d-flex justify-content-between align-items-center">
+    <span>(Page {{ $developers->currentPage() }} of {{ $developers->lastPage() }})</span>
+    <div class="d-flex gap-2">
+        @if ($developers->onFirstPage())
+            <span class="text-muted">Back</span>
+        @else
+            <a href="{{ $developers->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
+        @endif
+        @if ($developers->hasMorePages())
+            <a href="{{ $developers->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
+        @else
+            <span class="text-muted">Next</span>
+        @endif
+    </div>
+</div>
+
+<script>
+var developerSearchForm = document.getElementById('developer-search-form');
+var developerSearchInput = document.getElementById('developer-search-input');
+var developerSearchClear = document.getElementById('developer-search-clear');
+var developerSearchSpinner = document.getElementById('developer-search-spinner');
+var developerSearchTimer;
+
+function submitDeveloperSearch(){
+    developerSearchSpinner.classList.remove('d-none');
+    var params = new URLSearchParams(new FormData(developerSearchForm));
+    if(!developerSearchInput.value) { params.delete('q'); }
+    params.delete('page');
+    var query = params.toString();
+    window.location = developerSearchForm.getAttribute('action') + (query ? '?' + query : '');
+}
+
+developerSearchInput.addEventListener('input', function(){
+    developerSearchClear.style.display = this.value ? 'block' : 'none';
+    clearTimeout(developerSearchTimer);
+    developerSearchTimer = setTimeout(submitDeveloperSearch, 300);
+});
+
+developerSearchForm.addEventListener('submit', function(e){
+    e.preventDefault();
+    submitDeveloperSearch();
+});
+
+developerSearchClear.addEventListener('click', function(){
+    developerSearchInput.value = '';
+    submitDeveloperSearch();
+});
+</script>
+@endsection

--- a/resources/views/developer/show.blade.php
+++ b/resources/views/developer/show.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('title', 'Developer Detail')
+
+@section('content')
+<h1>Developer Detail</h1>
+<table class="table">
+    <tr><th>Name</th><td>{{ $developer->name }}</td></tr>
+    <tr><th>Email</th><td>{{ $developer->email }}</td></tr>
+    <tr><th>Phone</th><td>{{ $developer->phone }}</td></tr>
+    <tr><th>Role</th><td>{{ $developer->role }}</td></tr>
+</table>
+<a href="/developer" class="btn btn-secondary">Back</a>
+@if(session('role') === 'admin' || session('user_id') == $developer->id)
+    <a href="/developer/{{ $developer->id }}/edit" class="btn btn-primary">Edit</a>
+@endif
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,9 @@
             <a href="/" class="list-group-item list-group-item-action">Dashboard</a>
             <a href="/student" class="list-group-item list-group-item-action">Students</a>
             <a href="/supervisor" class="list-group-item list-group-item-action">Supervisors</a>
+            @if(in_array(session('role'), ['admin','developer']))
+            <a href="/developer" class="list-group-item list-group-item-action">Developers</a>
+            @endif
             <a href="/institution" class="list-group-item list-group-item-action">Institutions</a>
             <a href="/application" class="list-group-item list-group-item-action">Applications</a>
             <a href="/internship" class="list-group-item list-group-item-action">Internships</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\StudentController;
 use App\Http\Controllers\SupervisorController;
+use App\Http\Controllers\DeveloperController;
 use App\Http\Controllers\AdminUserController;
 use App\Http\Controllers\InstitutionController;
 use App\Http\Controllers\ApplicationController;
@@ -79,6 +80,18 @@ Route::middleware('auth.session')->group(function () {
             Route::get('{id}/edit', [SupervisorController::class, 'edit']);
             Route::put('{id}', [SupervisorController::class, 'update']);
             Route::delete('{id}', [SupervisorController::class, 'destroy']);
+        });
+    });
+
+    Route::prefix('developer')->group(function () {
+        Route::get('/', [DeveloperController::class, 'index']);
+        Route::get('/add', [DeveloperController::class, 'create']);
+        Route::post('/', [DeveloperController::class, 'store']);
+        Route::middleware('developer.self')->group(function () {
+            Route::get('{id}/see', [DeveloperController::class, 'show']);
+            Route::get('{id}/edit', [DeveloperController::class, 'edit']);
+            Route::put('{id}', [DeveloperController::class, 'update']);
+            Route::delete('{id}', [DeveloperController::class, 'destroy']);
         });
     });
 


### PR DESCRIPTION
## Summary
- add developer CRUD routes and controller with role-based access
- restrict self-access via middleware and update navigation

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ceee30148331a31190281bf2f57e