### PR TITLE
Add global header and profile dropdown with logout

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,6 +7,7 @@ use App\Models\Supervisor;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
 
 class AuthController extends Controller
 {
@@ -134,8 +135,9 @@ class AuthController extends Controller
 
     public function logout(Request $request)
     {
+        Auth::logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();
-        return redirect('/login');
+        return redirect('/login')->with('status', 'Anda telah keluar.');
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,8 +7,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body>
+@include('layouts.partials.header')
 <div class="d-flex">
-    <nav class="bg-light border-end" style="min-width:200px;">
+    <nav id="sidebar" class="bg-light border-end" style="min-width:200px;">
         <div class="list-group list-group-flush">
             <a href="/" class="list-group-item list-group-item-action">Dashboard</a>
             <a href="/student" class="list-group-item list-group-item-action">Students</a>
@@ -23,8 +24,8 @@
             @if(in_array(session('role'), ['admin','developer']))
             <a href="/admin" class="list-group-item list-group-item-action">Admin</a>
             @endif
-        </div>
-    </nav>
+    </div>
+</nav>
     <main class="p-4 flex-fill">
         @if (session('status'))
             <div class="alert alert-info">{{ session('status') }}</div>
@@ -33,5 +34,13 @@
     </main>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.getElementById('sidebarToggle').addEventListener('click', function(){
+    var sidebar = document.getElementById('sidebar');
+    var expanded = this.getAttribute('aria-expanded') === 'true';
+    sidebar.classList.toggle('d-none');
+    this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+});
+</script>
 </body>
 </html>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -1,0 +1,52 @@
+@php
+    $userId = session('user_id');
+    $role = session('role');
+    $user = \Illuminate\Support\Facades\DB::table('users')->where('id', $userId)->select('name')->first();
+    $name = $user->name ?? '';
+    $photo = null;
+    $settingsUrl = null;
+    if ($role === 'student') {
+        $student = \Illuminate\Support\Facades\DB::table('students')->where('user_id', $userId)->select('id','photo')->first();
+        if ($student) {
+            $photo = $student->photo;
+            $settingsUrl = route('student.edit', ['id' => $student->id]);
+        }
+    } elseif ($role === 'supervisor') {
+        $supervisor = \Illuminate\Support\Facades\DB::table('supervisors')->where('user_id', $userId)->select('id','photo')->first();
+        if ($supervisor) {
+            $photo = $supervisor->photo;
+            $settingsUrl = route('supervisor.edit', ['id' => $supervisor->id]);
+        }
+    } elseif ($role === 'admin') {
+        $settingsUrl = route('admin.edit', ['id' => $userId]);
+    } elseif ($role === 'developer') {
+        $settingsUrl = route('developer.edit', ['id' => $userId]);
+    }
+@endphp
+<header class="navbar navbar-light bg-light border-bottom px-3 d-flex align-items-center">
+    <button class="btn btn-outline-secondary me-3" id="sidebarToggle" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="true">
+        <i class="bi bi-list"></i>
+    </button>
+    <div class="dropdown ms-auto">
+        <button class="btn btn-light dropdown-toggle d-flex align-items-center" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+            @if($photo)
+                <img src="{{ $photo }}" alt="Foto profil" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+            @else
+                <i class="bi bi-person-circle fs-4 me-2"></i>
+            @endif
+            <span>{{ $name }}</span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+            @if($settingsUrl)
+            <li><a class="dropdown-item" href="{{ $settingsUrl }}">Pengaturan</a></li>
+            <li><hr class="dropdown-divider"></li>
+            @endif
+            <li>
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="dropdown-item">Logout</button>
+                </form>
+            </li>
+        </ul>
+    </div>
+</header>

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,7 +63,7 @@ Route::middleware('auth.session')->group(function () {
         Route::post('/', [StudentController::class, 'store']);
         Route::middleware('student.self')->group(function () {
             Route::get('{id}/see', [StudentController::class, 'show']);
-            Route::get('{id}/edit', [StudentController::class, 'edit']);
+            Route::get('{id}/edit', [StudentController::class, 'edit'])->name('student.edit');
             Route::put('{id}', [StudentController::class, 'update']);
             Route::delete('{id}', [StudentController::class, 'destroy']);
         });
@@ -77,7 +77,7 @@ Route::middleware('auth.session')->group(function () {
         });
         Route::middleware('supervisor.self')->group(function () {
             Route::get('{id}/see', [SupervisorController::class, 'show']);
-            Route::get('{id}/edit', [SupervisorController::class, 'edit']);
+            Route::get('{id}/edit', [SupervisorController::class, 'edit'])->name('supervisor.edit');
             Route::put('{id}', [SupervisorController::class, 'update']);
             Route::delete('{id}', [SupervisorController::class, 'destroy']);
         });
@@ -89,7 +89,7 @@ Route::middleware('auth.session')->group(function () {
         Route::post('/', [DeveloperController::class, 'store']);
         Route::middleware('developer.self')->group(function () {
             Route::get('{id}/see', [DeveloperController::class, 'show']);
-            Route::get('{id}/edit', [DeveloperController::class, 'edit']);
+            Route::get('{id}/edit', [DeveloperController::class, 'edit'])->name('developer.edit');
             Route::put('{id}', [DeveloperController::class, 'update']);
             Route::delete('{id}', [DeveloperController::class, 'destroy']);
         });
@@ -101,7 +101,7 @@ Route::middleware('auth.session')->group(function () {
         Route::post('/', [AdminUserController::class, 'store']);
         Route::middleware('admin.self')->group(function () {
             Route::get('{id}/see', [AdminUserController::class, 'show']);
-            Route::get('{id}/edit', [AdminUserController::class, 'edit']);
+            Route::get('{id}/edit', [AdminUserController::class, 'edit'])->name('admin.edit');
             Route::put('{id}', [AdminUserController::class, 'update']);
             Route::delete('{id}', [AdminUserController::class, 'destroy']);
         });


### PR DESCRIPTION
## Summary
- Add reusable header partial with sidebar toggle, user profile display, settings link and logout dropdown
- Update layout to include header and toggle script
- Enhance logout to clear authentication and flash a logout message; name edit routes for profile link

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d528d568833194126c45c49c8fe7