### PR TITLE
chore: replace bootstrap with tailwind

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/resources/views/components/form-errors.blade.php
+++ b/resources/views/components/form-errors.blade.php
@@ -1,6 +1,6 @@
 @if ($errors->any())
-    <div class="alert alert-danger">
-        <ul class="mb-0">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+        <ul class="mb-0 list-disc pl-5">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
             @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,43 +2,42 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>@yield('title', 'Internish')</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body>
 @include('layouts.partials.header')
-<div class="d-flex">
-    <nav id="sidebar" class="bg-light border-end" style="min-width:200px;">
-        <div class="list-group list-group-flush">
-            <a href="/" class="list-group-item list-group-item-action">Dashboard</a>
-            <a href="/student" class="list-group-item list-group-item-action">Students</a>
-            <a href="/supervisor" class="list-group-item list-group-item-action">Supervisors</a>
+<div class="flex">
+    <nav id="sidebar" class="bg-gray-100 border-r min-w-[200px]">
+        <div class="flex flex-col">
+            <a href="/" class="px-4 py-2 hover:bg-gray-200">Dashboard</a>
+            <a href="/student" class="px-4 py-2 hover:bg-gray-200">Students</a>
+            <a href="/supervisor" class="px-4 py-2 hover:bg-gray-200">Supervisors</a>
             @if(session('role') === 'developer')
-            <a href="/developer" class="list-group-item list-group-item-action">Developers</a>
+            <a href="/developer" class="px-4 py-2 hover:bg-gray-200">Developers</a>
             @endif
-            <a href="/institution" class="list-group-item list-group-item-action">Institutions</a>
-            <a href="/application" class="list-group-item list-group-item-action">Applications</a>
-            <a href="/internship" class="list-group-item list-group-item-action">Internships</a>
-            <a href="/monitoring" class="list-group-item list-group-item-action">Monitorings</a>
+            <a href="/institution" class="px-4 py-2 hover:bg-gray-200">Institutions</a>
+            <a href="/application" class="px-4 py-2 hover:bg-gray-200">Applications</a>
+            <a href="/internship" class="px-4 py-2 hover:bg-gray-200">Internships</a>
+            <a href="/monitoring" class="px-4 py-2 hover:bg-gray-200">Monitorings</a>
             @if(in_array(session('role'), ['admin','developer']))
-            <a href="/admin" class="list-group-item list-group-item-action">Admin</a>
+            <a href="/admin" class="px-4 py-2 hover:bg-gray-200">Admin</a>
             @endif
     </div>
 </nav>
-    <main class="p-4 flex-fill">
+    <main class="p-4 flex-1">
         @if (session('status'))
-            <div class="alert alert-info">{{ session('status') }}</div>
+            <div class="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded">{{ session('status') }}</div>
         @endif
         @yield('content')
     </main>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 document.getElementById('sidebarToggle').addEventListener('click', function(){
     var sidebar = document.getElementById('sidebar');
     var expanded = this.getAttribute('aria-expanded') === 'true';
-    sidebar.classList.toggle('d-none');
+    sidebar.classList.toggle('hidden');
     this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
 });
 </script>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -23,30 +23,33 @@
         $settingsUrl = route('developer.edit', ['id' => $userId]);
     }
 @endphp
-<header class="navbar navbar-light bg-light border-bottom px-3 d-flex align-items-center">
-    <button class="btn btn-outline-secondary me-3" id="sidebarToggle" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="true">
-        <i class="bi bi-list"></i>
-    </button>
-    <div class="dropdown ms-auto">
-        <button class="btn btn-light dropdown-toggle d-flex align-items-center" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+<header class="flex items-center bg-gray-100 border-b px-3">
+    <button class="border rounded px-2 py-1 text-gray-600 mr-3" id="sidebarToggle" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="true">☰</button>
+    <div class="relative ml-auto">
+        <button class="flex items-center px-2 py-1 border rounded" id="profileDropdown" aria-expanded="false">
             @if($photo)
-                <img src="{{ $photo }}" alt="Foto profil" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+                <img src="{{ $photo }}" alt="Foto profil" class="rounded-full mr-2" style="width:32px;height:32px;object-fit:cover;">
             @else
-                <i class="bi bi-person-circle fs-4 me-2"></i>
+                <span class="text-2xl mr-2">👤</span>
             @endif
             <span>{{ $name }}</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+        <ul class="absolute right-0 mt-2 w-40 bg-white border rounded shadow-lg hidden" id="profileMenu">
             @if($settingsUrl)
-            <li><a class="dropdown-item" href="{{ $settingsUrl }}">Pengaturan</a></li>
-            <li><hr class="dropdown-divider"></li>
+            <li><a class="block px-4 py-2 hover:bg-gray-100" href="{{ $settingsUrl }}">Pengaturan</a></li>
+            <li><hr class="my-1"></li>
             @endif
             <li>
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
-                    <button type="submit" class="dropdown-item">Logout</button>
+                    <button type="submit" class="w-full text-left px-4 py-2 hover:bg-gray-100">Logout</button>
                 </form>
             </li>
         </ul>
     </div>
 </header>
+<script>
+document.getElementById('profileDropdown').addEventListener('click', function(){
+    document.getElementById('profileMenu').classList.toggle('hidden');
+});
+</script>

--- a/resources/views/student/form.blade.php
+++ b/resources/views/student/form.blade.php
@@ -5,46 +5,46 @@
     @endif
 
     @include('components.form-errors')
-    <div class="mb-3">
-        <label class="form-label">Name</label>
-        <input type="text" name="name" class="form-control" value="{{ old('name', optional($student)->name) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Name</label>
+        <input type="text" name="name" class="w-full p-2 border rounded" value="{{ old('name', optional($student)->name) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Email</label>
-        <input type="email" name="email" class="form-control" value="{{ old('email', optional($student)->email) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Email</label>
+        <input type="email" name="email" class="w-full p-2 border rounded" value="{{ old('email', optional($student)->email) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Phone</label>
-        <input type="text" name="phone" class="form-control" value="{{ old('phone', optional($student)->phone) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Phone</label>
+        <input type="text" name="phone" class="w-full p-2 border rounded" value="{{ old('phone', optional($student)->phone) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Password</label>
-        <input type="password" name="password" class="form-control">
+    <div class="mb-4">
+        <label class="block mb-1">Password</label>
+        <input type="password" name="password" class="w-full p-2 border rounded">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Student Number</label>
-        <input type="text" name="student_number" class="form-control" value="{{ old('student_number', optional($student)->student_number) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Student Number</label>
+        <input type="text" name="student_number" class="w-full p-2 border rounded" value="{{ old('student_number', optional($student)->student_number) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">National Student Number</label>
-        <input type="text" name="national_sn" class="form-control" value="{{ old('national_sn', optional($student)->national_sn) }}">
+    <div class="mb-4">
+        <label class="block mb-1">National Student Number</label>
+        <input type="text" name="national_sn" class="w-full p-2 border rounded" value="{{ old('national_sn', optional($student)->national_sn) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Major</label>
-        <input type="text" name="major" class="form-control" value="{{ old('major', optional($student)->major) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Major</label>
+        <input type="text" name="major" class="w-full p-2 border rounded" value="{{ old('major', optional($student)->major) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Batch</label>
-        <input type="text" name="batch" class="form-control" value="{{ old('batch', optional($student)->batch) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Batch</label>
+        <input type="text" name="batch" class="w-full p-2 border rounded" value="{{ old('batch', optional($student)->batch) }}">
     </div>
-    <div class="mb-3">
-        <label class="form-label">Notes</label>
-        <textarea name="notes" class="form-control">{{ old('notes', optional($student)->notes) }}</textarea>
+    <div class="mb-4">
+        <label class="block mb-1">Notes</label>
+        <textarea name="notes" class="w-full p-2 border rounded">{{ old('notes', optional($student)->notes) }}</textarea>
     </div>
-    <div class="mb-3">
-        <label class="form-label">Photo</label>
-        <input type="text" name="photo" class="form-control" value="{{ old('photo', optional($student)->photo) }}">
+    <div class="mb-4">
+        <label class="block mb-1">Photo</label>
+        <input type="text" name="photo" class="w-full p-2 border rounded" value="{{ old('photo', optional($student)->photo) }}">
     </div>
-    <a href="/student" class="btn btn-secondary">Back</a>
-    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="/student" class="inline-block bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded">Back</a>
+    <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded">Save</button>
 </form>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+export default {
+  content: [
+    './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
+    './storage/framework/views/*.php',
+    './resources/views/**/*.blade.php',
+    './resources/js/**/*.js',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind configuration and PostCSS setup
- replace Bootstrap-based layout and header with Tailwind CSS utilities
- restyle student form and error component to use Tailwind classes

## Testing
- `npm run build` *(fails: vite: not found)*
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b7def02d088331901b7f048177707a