### PR TITLE
feat: integrate tailwind and refactor developer views

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
         "dev": "vite"
     },
     "devDependencies": {
-        "@tailwindcss/vite": "^4.0.0",
+        "autoprefixer": "^10.4.20",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^2.0.0",
-        "tailwindcss": "^4.0.0",
-        "vite": "^7.0.4"
+        "laravel-vite-plugin": "^2.0.1",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.4",
+        "vite": "^7.1.4"
     }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,11 +1,3 @@
-@import 'tailwindcss';
-
-@source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
-@source '../../storage/framework/views/*.php';
-@source '../**/*.blade.php';
-@source '../**/*.js';
-
-@theme {
-    --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-        'Segoe UI Symbol', 'Noto Color Emoji';
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,0 +1,13 @@
+@props(['type' => 'info'])
+
+@php
+$classes = [
+    'success' => 'border-green-200 bg-green-50 text-green-800',
+    'error' => 'border-red-200 bg-red-50 text-red-800',
+    'info' => 'border-blue-200 bg-blue-50 text-blue-800',
+];
+@endphp
+
+<div {{ $attributes->merge(['class' => "rounded-lg border p-3 " . ($classes[$type] ?? $classes['info'])]) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,0 +1,34 @@
+@props([
+    'variant' => 'primary',
+    'type' => 'button',
+    'size' => 'md',
+])
+
+@php
+$base = 'inline-flex items-center gap-2 rounded-lg font-medium focus:outline-none focus:ring-2 disabled:opacity-50';
+$variants = [
+    'primary' => 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
+    'secondary' => 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500',
+    'danger' => 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    'warning' => 'bg-yellow-500 text-white hover:bg-yellow-600 focus:ring-yellow-400',
+    'outline' => 'border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-gray-500',
+];
+$sizes = [
+    'sm' => 'px-2 py-1 text-xs',
+    'md' => 'px-4 py-2 text-sm',
+];
+@endphp
+
+@php
+$classes = "$base {$variants[$variant] ?? $variants['primary']} {$sizes[$size] ?? $sizes['md']}";
+@endphp
+
+@if ($attributes->has('href'))
+    <a {{ $attributes->merge(['class' => $classes]) }}>
+        {{ $slot }}
+    </a>
+@else
+    <button type="{{ $type }}" {{ $attributes->merge(['class' => $classes]) }}>
+        {{ $slot }}
+    </button>
+@endif

--- a/resources/views/components/form-errors.blade.php
+++ b/resources/views/components/form-errors.blade.php
@@ -1,9 +1,9 @@
 @if ($errors->any())
-    <div class="alert alert-danger">
-        <ul class="mb-0">
+    <x-alert type="error" class="mb-4">
+        <ul class="list-disc pl-5 space-y-1">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
             @endforeach
         </ul>
-    </div>
+    </x-alert>
 @endif

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,0 +1,18 @@
+@props([
+    'label' => null,
+    'id' => null,
+    'type' => 'text',
+    'name' => null,
+    'value' => null,
+    'error' => null,
+])
+
+<div>
+    @if($label)
+        <label for="{{ $id }}" class="mb-1 block text-sm font-medium text-gray-700">{{ $label }}</label>
+    @endif
+    <input type="{{ $type }}" id="{{ $id }}" name="{{ $name }}" value="{{ old($name, $value) }}" {{ $attributes->merge(['class' => 'block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500']) }} />
+    @if($error)
+        <p class="mt-1 text-xs text-red-600">{{ $error }}</p>
+    @endif
+</div>

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -1,0 +1,19 @@
+@props(['paginator'])
+
+@if ($paginator->hasPages())
+    <nav class="flex items-center gap-2">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span class="px-3 py-1.5 rounded border text-gray-300">Back</span>
+        @else
+            <a href="{{ $paginator->previousPageUrl() }}" class="px-3 py-1.5 rounded border hover:bg-gray-50">Back</a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a href="{{ $paginator->nextPageUrl() }}" class="px-3 py-1.5 rounded border hover:bg-gray-50">Next</a>
+        @else
+            <span class="px-3 py-1.5 rounded border text-gray-300">Next</span>
+        @endif
+    </nav>
+@endif

--- a/resources/views/developer/form.blade.php
+++ b/resources/views/developer/form.blade.php
@@ -1,4 +1,4 @@
-<form action="{{ $action }}" method="POST">
+<form action="{{ $action }}" method="POST" class="space-y-4">
     @csrf
     @if($method === 'PUT')
         @method('PUT')
@@ -6,22 +6,13 @@
 
     @include('components.form-errors')
 
-    <div class="mb-3">
-        <label class="form-label">Name</label>
-        <input type="text" name="name" class="form-control" value="{{ old('name', optional($developer)->name) }}">
+    <x-input label="Name" name="name" id="name" :value="old('name', optional($developer)->name)" :error="$errors->first('name')" />
+    <x-input label="Email" name="email" id="email" type="email" :value="old('email', optional($developer)->email)" :error="$errors->first('email')" />
+    <x-input label="Phone" name="phone" id="phone" :value="old('phone', optional($developer)->phone)" :error="$errors->first('phone')" />
+    <x-input label="Password" name="password" id="password" type="password" :error="$errors->first('password')" />
+
+    <div class="flex gap-2">
+        <x-button href="/developer" variant="secondary">Back</x-button>
+        <x-button type="submit">Save</x-button>
     </div>
-    <div class="mb-3">
-        <label class="form-label">Email</label>
-        <input type="email" name="email" class="form-control" value="{{ old('email', optional($developer)->email) }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Phone</label>
-        <input type="text" name="phone" class="form-control" value="{{ old('phone', optional($developer)->phone) }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Password</label>
-        <input type="password" name="password" class="form-control">
-    </div>
-    <a href="/developer" class="btn btn-secondary">Back</a>
-    <button type="submit" class="btn btn-primary">Save</button>
 </form>

--- a/resources/views/developer/index.blade.php
+++ b/resources/views/developer/index.blade.php
@@ -3,51 +3,52 @@
 @section('title', 'Developers')
 
 @section('content')
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h1>Developers</h1>
-    <div class="d-flex align-items-center gap-2">
-        <form method="get" action="{{ url()->current() }}" id="developer-search-form" class="position-relative">
-            <div class="input-group" style="min-width:280px;">
-                <input type="search" name="q" id="developer-search-input" class="form-control" placeholder="Cari…" aria-label="Search" value="{{ request('q') }}">
-                <button class="btn btn-outline-secondary" type="submit" id="developer-search-submit"><i class="bi bi-search"></i></button>
-                <button class="btn btn-outline-secondary" type="button" id="developer-search-clear" @if(!request('q')) style="display:none;" @endif><i class="bi bi-x"></i></button>
-            </div>
-            <div id="developer-search-spinner" class="position-absolute top-50 end-0 translate-middle-y me-2 d-none">
-                <div class="spinner-border spinner-border-sm text-secondary"></div>
+<div class="flex justify-between items-center mb-4">
+    <h1 class="text-xl font-semibold">Developers</h1>
+    <div class="flex items-center gap-2">
+        <form method="get" action="{{ url()->current() }}" id="developer-search-form" class="relative">
+            <input type="search" name="q" id="developer-search-input" class="block w-64 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Cari…" aria-label="Search" value="{{ request('q') }}">
+            <button class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500" id="developer-search-submit" type="submit">
+                🔍
+            </button>
+            <button class="hidden absolute right-8 top-1/2 -translate-y-1/2 text-gray-500" type="button" id="developer-search-clear">✖</button>
+            <div id="developer-search-spinner" class="hidden absolute right-2 top-1/2 -translate-y-1/2">
+                <svg class="h-4 w-4 animate-spin text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
             </div>
         </form>
-        <button class="btn btn-primary" disabled>Add</button>
+        <x-button variant="primary" disabled>Add</x-button>
     </div>
 </div>
 
-<table class="table table-bordered">
-    <thead>
+<div class="overflow-x-auto">
+<table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
         <tr>
-            <th>No</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Action</th>
+            <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">No</th>
+            <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Name</th>
+            <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Email</th>
+            <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Action</th>
         </tr>
     </thead>
-    <tbody>
+    <tbody class="divide-y divide-gray-200">
         @forelse($developers as $developer)
-        <tr>
-            <td>{{ $developers->total() - ($developers->currentPage() - 1) * $developers->perPage() - $loop->index }}</td>
-            <td>{{ $developer->name }}</td>
-            <td>{{ $developer->email }}</td>
-            <td>
-                <a href="/developer/{{ $developer->id }}/see" class="btn btn-sm btn-secondary">View</a>
+        <tr class="odd:bg-white even:bg-gray-50">
+            <td class="px-4 py-2">{{ $developers->total() - ($developers->currentPage() - 1) * $developers->perPage() - $loop->index }}</td>
+            <td class="px-4 py-2">{{ $developer->name }}</td>
+            <td class="px-4 py-2">{{ $developer->email }}</td>
+            <td class="px-4 py-2 space-x-2">
+                <x-button href="/developer/{{ $developer->id }}/see" variant="secondary" size="sm">View</x-button>
                 @if(session('user_id') == $developer->id)
-                    <a href="/developer/{{ $developer->id }}/edit" class="btn btn-sm btn-warning">Edit</a>
+                    <x-button href="/developer/{{ $developer->id }}/edit" variant="warning" size="sm">Edit</x-button>
                 @else
-                    <button class="btn btn-sm btn-warning" disabled>Edit</button>
+                    <x-button variant="warning" size="sm" disabled>Edit</x-button>
                 @endif
-                <button class="btn btn-sm btn-danger" disabled>Delete</button>
+                <x-button variant="danger" size="sm" disabled>Delete</x-button>
             </td>
         </tr>
         @empty
         <tr>
-            <td colspan="4" class="text-center">
+            <td colspan="4" class="px-4 py-2 text-center">
                 @if(request('q'))
                     Tidak ada hasil untuk '{{ request('q') }}'.
                 @else
@@ -58,23 +59,13 @@
         @endforelse
     </tbody>
 </table>
+</div>
 
-<p class="text-muted">Showing {{ $developers->count() }} out of {{ $developers->total() }} developers</p>
+<p class="mt-2 text-sm text-gray-600">Showing {{ $developers->count() }} out of {{ $developers->total() }} developers</p>
 
-<div class="d-flex justify-content-between align-items-center">
-    <span>(Page {{ $developers->currentPage() }} of {{ $developers->lastPage() }})</span>
-    <div class="d-flex gap-2">
-        @if ($developers->onFirstPage())
-            <span class="text-muted">Back</span>
-        @else
-            <a href="{{ $developers->previousPageUrl() }}" class="btn btn-outline-secondary">Back</a>
-        @endif
-        @if ($developers->hasMorePages())
-            <a href="{{ $developers->nextPageUrl() }}" class="btn btn-outline-secondary">Next</a>
-        @else
-            <span class="text-muted">Next</span>
-        @endif
-    </div>
+<div class="mt-4 flex justify-between items-center">
+    <span class="text-sm">(Page {{ $developers->currentPage() }} of {{ $developers->lastPage() }})</span>
+    <x-pagination :paginator="$developers" />
 </div>
 
 <script>
@@ -85,7 +76,7 @@ var developerSearchSpinner = document.getElementById('developer-search-spinner')
 var developerSearchTimer;
 
 function submitDeveloperSearch(){
-    developerSearchSpinner.classList.remove('d-none');
+    developerSearchSpinner.classList.remove('hidden');
     var params = new URLSearchParams(new FormData(developerSearchForm));
     if(!developerSearchInput.value) { params.delete('q'); }
     params.delete('page');
@@ -94,7 +85,7 @@ function submitDeveloperSearch(){
 }
 
 developerSearchInput.addEventListener('input', function(){
-    developerSearchClear.style.display = this.value ? 'block' : 'none';
+    developerSearchClear.classList.toggle('hidden', !this.value);
     clearTimeout(developerSearchTimer);
     developerSearchTimer = setTimeout(submitDeveloperSearch, 300);
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,42 +3,41 @@
 <head>
     <meta charset="utf-8">
     <title>@yield('title', 'Internish')</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body>
+<body class="min-h-screen bg-gray-50">
 @include('layouts.partials.header')
-<div class="d-flex">
-    <nav id="sidebar" class="bg-light border-end" style="min-width:200px;">
-        <div class="list-group list-group-flush">
-            <a href="/" class="list-group-item list-group-item-action">Dashboard</a>
-            <a href="/student" class="list-group-item list-group-item-action">Students</a>
-            <a href="/supervisor" class="list-group-item list-group-item-action">Supervisors</a>
+<div class="flex">
+    <nav id="sidebar" class="hidden md:block w-64 bg-white border-r">
+        <div class="p-4 space-y-1">
+            <a href="/" class="block rounded px-3 py-2 hover:bg-gray-100">Dashboard</a>
+            <a href="/student" class="block rounded px-3 py-2 hover:bg-gray-100">Students</a>
+            <a href="/supervisor" class="block rounded px-3 py-2 hover:bg-gray-100">Supervisors</a>
             @if(session('role') === 'developer')
-            <a href="/developer" class="list-group-item list-group-item-action">Developers</a>
+            <a href="/developer" class="block rounded px-3 py-2 hover:bg-gray-100">Developers</a>
             @endif
-            <a href="/institution" class="list-group-item list-group-item-action">Institutions</a>
-            <a href="/application" class="list-group-item list-group-item-action">Applications</a>
-            <a href="/internship" class="list-group-item list-group-item-action">Internships</a>
-            <a href="/monitoring" class="list-group-item list-group-item-action">Monitorings</a>
+            <a href="/institution" class="block rounded px-3 py-2 hover:bg-gray-100">Institutions</a>
+            <a href="/application" class="block rounded px-3 py-2 hover:bg-gray-100">Applications</a>
+            <a href="/internship" class="block rounded px-3 py-2 hover:bg-gray-100">Internships</a>
+            <a href="/monitoring" class="block rounded px-3 py-2 hover:bg-gray-100">Monitorings</a>
             @if(in_array(session('role'), ['admin','developer']))
-            <a href="/admin" class="list-group-item list-group-item-action">Admin</a>
+            <a href="/admin" class="block rounded px-3 py-2 hover:bg-gray-100">Admin</a>
             @endif
     </div>
 </nav>
-    <main class="p-4 flex-fill">
+    <main class="p-4 flex-1">
         @if (session('status'))
-            <div class="alert alert-info">{{ session('status') }}</div>
+            <x-alert type="info">{{ session('status') }}</x-alert>
         @endif
         @yield('content')
     </main>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-document.getElementById('sidebarToggle').addEventListener('click', function(){
+document.getElementById('sidebarToggle')?.addEventListener('click', function(){
     var sidebar = document.getElementById('sidebar');
     var expanded = this.getAttribute('aria-expanded') === 'true';
-    sidebar.classList.toggle('d-none');
+    sidebar.classList.toggle('hidden');
     this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
 });
 </script>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -23,28 +23,29 @@
         $settingsUrl = route('developer.edit', ['id' => $userId]);
     }
 @endphp
-<header class="navbar navbar-light bg-light border-bottom px-3 d-flex align-items-center">
-    <button class="btn btn-outline-secondary me-3" id="sidebarToggle" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="true">
-        <i class="bi bi-list"></i>
+<header class="sticky top-0 z-50 bg-white/80 backdrop-blur border-b px-3 flex items-center">
+    <button class="p-2 rounded-lg border md:hidden" id="sidebarToggle" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="true">
+        <span class="sr-only">Toggle menu</span>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
     </button>
-    <div class="dropdown ms-auto">
-        <button class="btn btn-light dropdown-toggle d-flex align-items-center" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+    <div class="ml-auto relative" x-data="{open:false}">
+        <button @click="open=!open" :aria-expanded="open.toString()" class="flex items-center gap-2 rounded-lg border px-3 py-2">
             @if($photo)
-                <img src="{{ $photo }}" alt="Foto profil" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+                <img src="{{ $photo }}" alt="Foto profil" class="rounded-full w-8 h-8 object-cover">
             @else
-                <i class="bi bi-person-circle fs-4 me-2"></i>
+                <span class="inline-block w-8 h-8 rounded-full bg-gray-200"></span>
             @endif
             <span>{{ $name }}</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+        <ul x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-40 rounded-lg border bg-white shadow-md py-1">
             @if($settingsUrl)
-            <li><a class="dropdown-item" href="{{ $settingsUrl }}">Pengaturan</a></li>
-            <li><hr class="dropdown-divider"></li>
+            <li><a class="block px-4 py-2 hover:bg-gray-50" href="{{ $settingsUrl }}">Pengaturan</a></li>
+            <li><hr class="my-1"></li>
             @endif
             <li>
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
-                    <button type="submit" class="dropdown-item">Logout</button>
+                    <button type="submit" class="block w-full text-left px-4 py-2 hover:bg-gray-50">Logout</button>
                 </form>
             </li>
         </ul>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,24 @@
+export default {
+  content: [
+    "./resources/views/**/*.blade.php",
+    "./resources/js/**/*.js",
+    "./resources/js/**/*.ts",
+    "./resources/**/*.vue",
+    "./app/View/**/*.php",
+  ],
+  safelist: [
+    {
+      pattern: /(bg-(red|green|blue|gray)-(500|600))/, 
+    },
+    {
+      pattern: /(text-(red|green|blue)-(600|700))/, 
+    },
+    {
+      pattern: /(hidden|block|flex|grid|col-span-\d+|row-span-\d+)/,
+    },
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
     plugins: [
@@ -8,6 +7,5 @@ export default defineConfig({
             input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
-        tailwindcss(),
     ],
 });


### PR DESCRIPTION
## Summary
- configure Tailwind with PostCSS and autoprefixer
- add reusable Tailwind Blade components and layout updates
- convert developer pages from Bootstrap to Tailwind

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm run build` *(fails: Cannot find module 'autoprefixer')*
- `php artisan view:clear && php artisan route:clear`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b8e1c689488331814b58a33d411eb3