### PR TITLE
Add class to students and industry to institutions

### DIFF
--- a/app/Http/Controllers/InstitutionController.php
+++ b/app/Http/Controllers/InstitutionController.php
@@ -15,8 +15,8 @@ class InstitutionController extends Controller
     /**
      * Columns searched and displayed. Adjust here if needed.
      */
-    private const SEARCH_COLUMNS = ['name', 'city', 'province'];
-    private const DISPLAY_COLUMNS = ['id', 'name', 'city', 'province'];
+    private const SEARCH_COLUMNS = ['name', 'city', 'province', 'industry'];
+    private const DISPLAY_COLUMNS = ['id', 'name', 'city', 'province', 'industry'];
 
     protected function loadRegions(): array
     {
@@ -29,7 +29,7 @@ class InstitutionController extends Controller
     {
         $query = DB::table('institution_details_view as iv')
             ->join('institutions as i', 'i.id', '=', 'iv.id')
-            ->select('iv.id', 'iv.name', 'iv.city', 'iv.province', 'i.created_at', 'i.updated_at');
+            ->select('iv.id', 'iv.name', 'iv.city', 'iv.province', 'iv.industry', 'i.created_at', 'i.updated_at');
 
         if (session('role') === 'student') {
             $studentId = $this->currentStudentId();
@@ -140,6 +140,7 @@ class InstitutionController extends Controller
             'city' => 'required|string',
             'province' => 'required|string',
             'website' => 'nullable|string',
+            'industry' => 'required|string|max:100',
             'photo' => 'nullable|string',
             'contact_name' => 'required|string',
             'contact_email' => 'nullable|email',
@@ -160,6 +161,7 @@ class InstitutionController extends Controller
                 'city' => $data['city'],
                 'province' => $data['province'],
                 'website' => $data['website'] ?? null,
+                'industry' => $data['industry'],
                 'photo' => $data['photo'] ?? null,
             ]);
 
@@ -225,6 +227,7 @@ class InstitutionController extends Controller
             'city' => 'required|string',
             'province' => 'required|string',
             'website' => 'nullable|string',
+            'industry' => 'required|string|max:100',
             'photo' => 'nullable|string',
             'contact_name' => 'required|string',
             'contact_email' => 'nullable|email',
@@ -245,6 +248,7 @@ class InstitutionController extends Controller
                 'city' => $data['city'],
                 'province' => $data['province'],
                 'website' => $data['website'] ?? null,
+                'industry' => $data['industry'],
                 'photo' => $data['photo'] ?? null,
             ]);
 

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -14,8 +14,8 @@ class StudentController extends Controller
     /**
      * Columns searched and displayed. Adjust here if needed.
      */
-    private const SEARCH_COLUMNS = ['name', 'major'];
-    private const DISPLAY_COLUMNS = ['id', 'name', 'major'];
+    private const SEARCH_COLUMNS = ['name', 'major', 'class'];
+    private const DISPLAY_COLUMNS = ['id', 'name', 'major', 'class'];
 
     public function index(Request $request)
     {
@@ -125,6 +125,7 @@ class StudentController extends Controller
             'student_number' => 'required|string|unique:students,student_number',
             'national_sn' => 'required|string|unique:students,national_sn',
             'major' => 'required|string',
+            'class' => 'required|string|max:100',
             'batch' => 'required|string',
             'notes' => 'nullable|string',
             'photo' => 'nullable|string',
@@ -143,6 +144,7 @@ class StudentController extends Controller
             'student_number' => $data['student_number'],
             'national_sn' => $data['national_sn'],
             'major' => $data['major'],
+            'class' => $data['class'],
             'batch' => $data['batch'],
             'notes' => $data['notes'] ?? null,
             'photo' => $data['photo'] ?? null,
@@ -177,6 +179,7 @@ class StudentController extends Controller
             'student_number' => 'required|string|unique:students,student_number,' . $student->id,
             'national_sn' => 'required|string|unique:students,national_sn,' . $student->id,
             'major' => 'required|string',
+            'class' => 'required|string|max:100',
             'batch' => 'required|string',
             'notes' => 'nullable|string',
             'photo' => 'nullable|string',
@@ -194,6 +197,7 @@ class StudentController extends Controller
             'student_number' => $data['student_number'],
             'national_sn' => $data['national_sn'],
             'major' => $data['major'],
+            'class' => $data['class'],
             'batch' => $data['batch'],
             'notes' => $data['notes'] ?? null,
             'photo' => $data['photo'] ?? null,

--- a/app/Models/Institution.php
+++ b/app/Models/Institution.php
@@ -15,6 +15,7 @@ class Institution extends Model
         'city',
         'province',
         'website',
+        'industry',
         'notes',
         'photo',
     ];

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -14,9 +14,14 @@ class Student extends Model
         'student_number',
         'national_sn',
         'major',
+        'class',
         'batch',
         'notes',
         'photo',
+    ];
+
+    protected $casts = [
+        'class' => 'string',
     ];
 
     public function user()

--- a/database/factories/InstitutionFactory.php
+++ b/database/factories/InstitutionFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Institution;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Institution>
+ */
+class InstitutionFactory extends Factory
+{
+    protected $model = Institution::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'address' => $this->faker->streetAddress(),
+            'city' => $this->faker->city(),
+            'province' => $this->faker->state(),
+            'website' => $this->faker->url(),
+            'industry' => $this->faker->randomElement(['Technology','Manufacturing','Healthcare','Finance','Education']),
+            'notes' => null,
+            'photo' => null,
+        ];
+    }
+}

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Student;
+use App\Models\User;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Student>
+ */
+class StudentFactory extends Factory
+{
+    protected $model = Student::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->state(['role' => 'student']),
+            'student_number' => $this->faker->unique()->bothify('S-####'),
+            'national_sn' => $this->faker->unique()->bothify('NSN-####'),
+            'major' => $this->faker->randomElement(['Computer Science', 'Information Systems', 'Engineering']),
+            'class' => $this->faker->bothify('XI-?? #'),
+            'batch' => (string) $this->faker->year(),
+            'notes' => null,
+            'photo' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_09_04_023201_add_class_to_students_and_industry_to_institutions.php
+++ b/database/migrations/2025_09_04_023201_add_class_to_students_and_industry_to_institutions.php
@@ -1,0 +1,167 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('students', function (Blueprint $table) {
+            $table->string('class', 100)->default('');
+        });
+
+        DB::table('students')->where('class', '')->update(['class' => 'Unknown']);
+        DB::statement("ALTER TABLE students ALTER COLUMN class SET NOT NULL");
+        DB::statement("ALTER TABLE students ALTER COLUMN class DROP DEFAULT");
+        Schema::table('students', function (Blueprint $table) {
+            $table->index('class');
+        });
+
+        Schema::table('institutions', function (Blueprint $table) {
+            $table->string('industry', 100)->default('');
+        });
+
+        DB::table('institutions')->where('industry', '')->update(['industry' => 'Unknown']);
+        DB::statement("ALTER TABLE institutions ALTER COLUMN industry SET NOT NULL");
+        DB::statement("ALTER TABLE institutions ALTER COLUMN industry DROP DEFAULT");
+        Schema::table('institutions', function (Blueprint $table) {
+            $table->index('industry');
+        });
+
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW student_details_view AS
+            SELECT s.id,
+                   u.id AS user_id,
+                   u.name,
+                   u.email,
+                   u.phone,
+                   u.role,
+                   s.student_number,
+                   s.national_sn,
+                   s.major,
+                   s.class,
+                   s.batch,
+                   s.notes,
+                   s.photo,
+                   s.created_at,
+                   s.updated_at
+            FROM students s
+            JOIN users u ON s.user_id = u.id;
+        SQL);
+
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW institution_details_view AS
+            WITH primary_contact AS (
+                SELECT DISTINCT ON (institution_id) id, institution_id, name, email, phone, position, is_primary
+                FROM institution_contacts
+                ORDER BY institution_id, is_primary DESC, id
+            ),
+            latest_quota AS (
+                SELECT DISTINCT ON (institution_id) iq.id, iq.institution_id, iq.quota, iq.used, iq.notes, p.year, p.term
+                FROM institution_quotas iq
+                JOIN periods p ON p.id = iq.period_id
+                ORDER BY iq.institution_id, p.year DESC, p.term DESC, iq.id DESC
+            )
+            SELECT i.id,
+                   i.name,
+                   i.address,
+                   i.city,
+                   i.province,
+                   i.website,
+                   i.industry,
+                   i.notes,
+                   i.photo,
+                   pc.name AS contact_name,
+                   pc.email AS contact_email,
+                   pc.phone AS contact_phone,
+                   pc.position AS contact_position,
+                   pc.is_primary AS contact_primary,
+                   lq.year AS period_year,
+                   lq.term AS period_term,
+                   lq.quota,
+                   lq.used,
+                   lq.notes AS quota_notes
+            FROM institutions i
+            LEFT JOIN primary_contact pc ON pc.institution_id = i.id
+            LEFT JOIN latest_quota lq ON lq.institution_id = i.id;
+        SQL);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW student_details_view AS
+            SELECT s.id,
+                   u.id AS user_id,
+                   u.name,
+                   u.email,
+                   u.phone,
+                   u.role,
+                   s.student_number,
+                   s.national_sn,
+                   s.major,
+                   s.batch,
+                   s.notes,
+                   s.photo,
+                   s.created_at,
+                   s.updated_at
+            FROM students s
+            JOIN users u ON s.user_id = u.id;
+        SQL);
+
+        DB::statement(<<<'SQL'
+            CREATE OR REPLACE VIEW institution_details_view AS
+            WITH primary_contact AS (
+                SELECT DISTINCT ON (institution_id) id, institution_id, name, email, phone, position, is_primary
+                FROM institution_contacts
+                ORDER BY institution_id, is_primary DESC, id
+            ),
+            latest_quota AS (
+                SELECT DISTINCT ON (institution_id) iq.id, iq.institution_id, iq.quota, iq.used, iq.notes, p.year, p.term
+                FROM institution_quotas iq
+                JOIN periods p ON p.id = iq.period_id
+                ORDER BY iq.institution_id, p.year DESC, p.term DESC, iq.id DESC
+            )
+            SELECT i.id,
+                   i.name,
+                   i.address,
+                   i.city,
+                   i.province,
+                   i.website,
+                   i.notes,
+                   i.photo,
+                   pc.name AS contact_name,
+                   pc.email AS contact_email,
+                   pc.phone AS contact_phone,
+                   pc.position AS contact_position,
+                   pc.is_primary AS contact_primary,
+                   lq.year AS period_year,
+                   lq.term AS period_term,
+                   lq.quota,
+                   lq.used,
+                   lq.notes AS quota_notes
+            FROM institutions i
+            LEFT JOIN primary_contact pc ON pc.institution_id = i.id
+            LEFT JOIN latest_quota lq ON lq.institution_id = i.id;
+        SQL);
+
+        Schema::table('students', function (Blueprint $table) {
+            $table->dropIndex(['class']);
+            $table->dropColumn('class');
+        });
+
+        Schema::table('institutions', function (Blueprint $table) {
+            $table->dropIndex(['industry']);
+            $table->dropColumn('industry');
+        });
+    }
+};

--- a/database/seeders/InstitutionSeeder.php
+++ b/database/seeders/InstitutionSeeder.php
@@ -18,6 +18,7 @@ class InstitutionSeeder extends Seeder
                 'city' => $faker->city,
                 'province' => $faker->state,
                 'website' => $faker->url,
+                'industry' => $faker->randomElement(['Technology','Manufacturing','Healthcare','Finance','Education']),
             ]);
         }
     }

--- a/database/seeders/StudentSeeder.php
+++ b/database/seeders/StudentSeeder.php
@@ -17,6 +17,7 @@ class StudentSeeder extends Seeder
                 'student_number' => 'S-' . str_pad($i, 4, '0', STR_PAD_LEFT),
                 'national_sn' => 'NSN-' . str_pad($i, 4, '0', STR_PAD_LEFT),
                 'major' => $faker->randomElement(['Computer Science', 'Information Systems', 'Engineering']),
+                'class' => $faker->bothify('XI-?? #'),
                 'batch' => (string)(2020 + $i),
             ]);
         }

--- a/main.sql
+++ b/main.sql
@@ -146,6 +146,7 @@ CREATE TABLE students (
     student_number VARCHAR(50) NOT NULL UNIQUE,
     national_sn VARCHAR(50) NOT NULL UNIQUE,
     major VARCHAR(100) NOT NULL,
+    class VARCHAR(100) NOT NULL,
     batch VARCHAR(9) NOT NULL,
     notes TEXT,
     photo TEXT,
@@ -157,6 +158,7 @@ CREATE TRIGGER trg_students_updated_at BEFORE UPDATE ON students
     FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 CREATE TRIGGER trg_students_role BEFORE INSERT OR UPDATE OF user_id ON students
     FOR EACH ROW EXECUTE FUNCTION enforce_role_student();
+CREATE INDEX idx_students_class ON students (class);
 
 CREATE TABLE supervisors (
     id BIGSERIAL PRIMARY KEY,
@@ -181,6 +183,7 @@ CREATE TABLE institutions (
     city VARCHAR(100),
     province VARCHAR(100),
     website TEXT,
+    industry VARCHAR(100) NOT NULL,
     notes TEXT,
     photo VARCHAR(255),
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -188,6 +191,7 @@ CREATE TABLE institutions (
 );
 CREATE TRIGGER trg_institutions_updated_at BEFORE UPDATE ON institutions
     FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE INDEX idx_institutions_industry ON institutions (industry);
 
 CREATE TABLE institution_contacts (
     id BIGSERIAL PRIMARY KEY,
@@ -374,6 +378,7 @@ SELECT s.id,
        s.student_number,
        s.national_sn,
        s.major,
+       s.class,
        s.batch,
        s.notes,
        s.photo,
@@ -416,6 +421,7 @@ SELECT i.id,
        i.city,
        i.province,
        i.website,
+       i.industry,
        i.notes,
        i.photo,
        pc.name AS contact_name,

--- a/resources/views/institution/form.blade.php
+++ b/resources/views/institution/form.blade.php
@@ -32,6 +32,10 @@
         </select>
     </div>
     <div class="mb-3">
+        <label class="form-label">Industry</label>
+        <input type="text" name="industry" class="form-control" value="{{ old('industry', optional($institution)->industry) }}">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Website</label>
         <textarea name="website" class="form-control">{{ old('website', optional($institution)->website) }}</textarea>
     </div>

--- a/resources/views/institution/index.blade.php
+++ b/resources/views/institution/index.blade.php
@@ -53,6 +53,7 @@
             <th>Name</th>
             <th>City</th>
             <th>Province</th>
+            <th>Industry</th>
             <th>Action</th>
         </tr>
     </thead>
@@ -63,6 +64,7 @@
             <td>{{ $institution->name }}</td>
             <td>{{ $institution->city }}</td>
             <td>{{ $institution->province }}</td>
+            <td>{{ $institution->industry }}</td>
             <td>
                 <a href="/institution/{{ $institution->id }}/see" class="btn btn-sm btn-secondary">View</a>
                 @if($isStudent)

--- a/resources/views/institution/show.blade.php
+++ b/resources/views/institution/show.blade.php
@@ -19,6 +19,7 @@
             <li>City: {{ $institution->city }}</li>
             <li>Province: {{ $institution->province }}</li>
             <li>Website: {{ $institution->website }}</li>
+            <li>Industry: {{ $institution->industry }}</li>
             <li>Contact Name: {{ $institution->contact_name }}</li>
             <li>Contact Email: {{ $institution->contact_email }}</li>
             <li>Contact Phone: {{ $institution->contact_phone }}</li>

--- a/resources/views/student/form.blade.php
+++ b/resources/views/student/form.blade.php
@@ -38,6 +38,10 @@
         <input type="text" name="batch" class="form-control" value="{{ old('batch', optional($student)->batch) }}">
     </div>
     <div class="mb-3">
+        <label class="form-label">Class</label>
+        <input type="text" name="class" class="form-control" value="{{ old('class', optional($student)->class) }}">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Notes</label>
         <textarea name="notes" class="form-control">{{ old('notes', optional($student)->notes) }}</textarea>
     </div>

--- a/resources/views/student/index.blade.php
+++ b/resources/views/student/index.blade.php
@@ -56,6 +56,7 @@
             <th>No</th>
             <th>Name</th>
             <th>Major</th>
+            <th>Class</th>
             <th>Action</th>
         </tr>
     </thead>
@@ -65,6 +66,7 @@
             <td>{{ $students->total() - ($students->currentPage() - 1) * $students->perPage() - $loop->index }}</td>
             <td>{{ $student->name }}</td>
             <td>{{ $student->major }}</td>
+            <td>{{ $student->class }}</td>
             <td>
                 <a href="/student/{{ $student->id }}/see" class="btn btn-sm btn-secondary">View</a>
                 @if($isStudent)

--- a/resources/views/student/show.blade.php
+++ b/resources/views/student/show.blade.php
@@ -22,6 +22,7 @@
             <li>Student Number: {{ $student->student_number }}</li>
             <li>National Student Number: {{ $student->national_sn }}</li>
             <li>Major: {{ $student->major }}</li>
+            <li>Class: {{ $student->class }}</li>
             <li>Batch: {{ $student->batch }}</li>
             <li>Notes: {{ $student->notes }}</li>
         </ul>

--- a/tests/Feature/InstitutionIndustryTest.php
+++ b/tests/Feature/InstitutionIndustryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Institution;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class InstitutionIndustryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('institutions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('province')->nullable();
+            $table->string('website')->nullable();
+            $table->string('industry');
+            $table->text('notes')->nullable();
+            $table->string('photo')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('institutions');
+        parent::tearDown();
+    }
+
+    public function test_industry_is_saved_and_updated(): void
+    {
+        $institution = Institution::create([
+            'name' => 'Acme Inc',
+            'industry' => 'Technology',
+        ]);
+
+        $this->assertDatabaseHas('institutions', [
+            'id' => $institution->id,
+            'industry' => 'Technology',
+        ]);
+
+        $institution->update(['industry' => 'Finance']);
+
+        $this->assertDatabaseHas('institutions', [
+            'id' => $institution->id,
+            'industry' => 'Finance',
+        ]);
+    }
+}

--- a/tests/Feature/StudentClassTest.php
+++ b/tests/Feature/StudentClassTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class StudentClassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('role')->default('student');
+            $table->timestamps();
+        });
+
+        Schema::create('students', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('student_number');
+            $table->string('national_sn');
+            $table->string('major');
+            $table->string('class');
+            $table->string('batch');
+            $table->text('notes')->nullable();
+            $table->text('photo')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('students');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_student_class_is_saved_and_updated(): void
+    {
+        $user = User::create([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => Hash::make('secret'),
+            'role' => 'student',
+        ]);
+
+        $student = Student::create([
+            'user_id' => $user->id,
+            'student_number' => 'S-0001',
+            'national_sn' => 'NSN-0001',
+            'major' => 'CS',
+            'class' => 'XI RPL 1',
+            'batch' => '2024',
+        ]);
+
+        $this->assertDatabaseHas('students', [
+            'id' => $student->id,
+            'class' => 'XI RPL 1',
+        ]);
+
+        $student->update(['class' => 'XII-A']);
+
+        $this->assertDatabaseHas('students', [
+            'id' => $student->id,
+            'class' => 'XII-A',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `class` to students and `industry` to institutions with indexes
- expose new fields across models, controllers, views, factories, seeders, and SQL schema
- include feature tests for creating and updating the new fields

## Testing
- `php artisan test`
- `php artisan migrate` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*
- `php artisan db:seed` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f95de16c83318c624e18f824501f