### PR TITLE
Enable searchable selects with Tom Select

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,34 @@
 import './bootstrap';
+
+function initTom(root = document) {
+    let elements = [];
+    if (root.tagName === 'SELECT') {
+        if (!root.hasAttribute('data-no-search')) {
+            elements = [root];
+        }
+    } else {
+        elements = Array.from(root.querySelectorAll('select:not([data-no-search])'));
+    }
+
+    elements.forEach((el) => {
+        if (el.tomselect) return;
+        new TomSelect(el);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (typeof TomSelect === 'undefined') return;
+    initTom();
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            mutation.addedNodes.forEach((node) => {
+                if (!(node instanceof HTMLElement)) return;
+                initTom(node);
+            });
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+});
+

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Register</title>
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
 </head>
 <body>
 @if ($errors->any())
@@ -34,7 +35,7 @@
     </div>
     <div>
         <label>Role</label>
-        <select name="role" required>
+        <select name="role" required data-no-search>
             <option value="">Select role</option>
             @foreach (['student','supervisor'] as $role)
                 <option value="{{ $role }}" {{ (old('role', $data['role'] ?? '') === $role) ? 'selected' : '' }}>{{ ucfirst($role) }}</option>
@@ -86,5 +87,7 @@
     <button type="submit">Sign Up</button>
 </form>
 @endif
+<script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
+@vite('resources/js/app.js')
 </body>
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>@yield('title', 'Internish')</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body>
@@ -33,6 +34,8 @@
         @yield('content')
     </main>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
+@vite('resources/js/app.js')
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 document.getElementById('sidebarToggle').addEventListener('click', function(){


### PR DESCRIPTION
## Summary
- add Tom Select assets and global initializer to make selects searchable
- keep register role dropdown native via `data-no-search`

## Testing
- `npm run build`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b8ff99f3588331afec8913f46ab351