### PR TITLE
Make selects searchable and add student dropdown

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,33 @@
 import './bootstrap';
+
+function initSearchableSelect(select) {
+    if (select.classList.contains('no-search') || select.dataset.searchable === 'false') {
+        return;
+    }
+    if (select.dataset.searchableInit) {
+        return;
+    }
+    select.dataset.searchableInit = '1';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'searchable-select-wrapper';
+    select.parentNode.insertBefore(wrapper, select);
+    wrapper.appendChild(select);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'form-control mb-2 searchable-select-input';
+    input.placeholder = 'Search...';
+    wrapper.insertBefore(input, select);
+
+    input.addEventListener('input', () => {
+        const term = input.value.toLowerCase();
+        Array.from(select.options).forEach(opt => {
+            opt.hidden = term && !opt.text.toLowerCase().includes(term);
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('select').forEach(initSearchableSelect);
+});

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -34,7 +34,7 @@
     </div>
     <div>
         <label>Role</label>
-        <select name="role" required>
+        <select name="role" class="no-search" required>
             <option value="">Select role</option>
             @foreach (['student','supervisor'] as $role)
                 <option value="{{ $role }}" {{ (old('role', $data['role'] ?? '') === $role) ? 'selected' : '' }}>{{ ucfirst($role) }}</option>

--- a/resources/views/institution/create.blade.php
+++ b/resources/views/institution/create.blade.php
@@ -4,5 +4,5 @@
 
 @section('content')
 <h1>Add Institution</h1>
-@include('institution.form', ['action' => '/institution', 'method' => 'POST', 'institution' => null, 'cities' => $cities, 'provinces' => $provinces])
+@include('institution.form', ['action' => '/institution', 'method' => 'POST', 'institution' => null, 'cities' => $cities, 'provinces' => $provinces, 'students' => $students])
 @endsection

--- a/resources/views/institution/edit.blade.php
+++ b/resources/views/institution/edit.blade.php
@@ -4,5 +4,5 @@
 
 @section('content')
 <h1>Edit Institution</h1>
-@include('institution.form', ['action' => "/institution/{$institution->id}", 'method' => 'PUT', 'institution' => $institution, 'cities' => $cities, 'provinces' => $provinces])
+@include('institution.form', ['action' => "/institution/{$institution->id}", 'method' => 'PUT', 'institution' => $institution, 'cities' => $cities, 'provinces' => $provinces, 'students' => $students])
 @endsection

--- a/resources/views/institution/form.blade.php
+++ b/resources/views/institution/form.blade.php
@@ -36,6 +36,17 @@
         <input type="text" name="industry" class="form-control" value="{{ old('industry', optional($institution)->industry) }}">
     </div>
     <div class="mb-3">
+        <label class="form-label">Student Name</label>
+        <select name="student_id" class="form-control">
+            <option value="">-- Select Student --</option>
+            @foreach($students as $student)
+                <option value="{{ $student->id }}" {{ old('student_id', optional($institution)->student_id) == $student->id ? 'selected' : '' }}>
+                    {{ $student->user->name }}{{ $student->student_number ? ' (' . $student->student_number . ')' : '' }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
         <label class="form-label">Website</label>
         <textarea name="website" class="form-control">{{ old('website', optional($institution)->website) }}</textarea>
     </div>


### PR DESCRIPTION
## Summary
- add lightweight JS to attach a search box to every `<select>` element
- exclude profile role dropdown and wire up Student Name dropdown on institution create/edit

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b903019c7c8331828e300a4fcd09b6