### PR TITLE
Enable visible search in Tom Select dropdowns

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tom-select/dist/css/tom-select.bootstrap5.css';
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
@@ -8,4 +9,16 @@
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
+}
+
+.ts-dropdown .dropdown-input {
+    padding: 0.5rem;
+}
+
+.ts-dropdown .dropdown-input input {
+    width: 100%;
+}
+
+.ts-wrapper.single .ts-control {
+    min-height: calc(1.5em + 0.75rem + 2px);
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,16 @@
 import './bootstrap';
+import TomSelect from 'tom-select';
+import 'tom-select/dist/css/tom-select.bootstrap5.css';
+
+window.initTomSelect = () => {
+    document.querySelectorAll('select.tom-select').forEach((el) => {
+        if (el.tomselect) return;
+        new TomSelect(el, {
+            plugins: { dropdown_input: {} },
+        });
+    });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.initTomSelect();
+});

--- a/resources/views/application/form.blade.php
+++ b/resources/views/application/form.blade.php
@@ -8,7 +8,7 @@
 
     <div class="mb-3">
         <label class="form-label">Student Name</label>
-        <select name="student_id" class="form-select">
+        <select name="student_id" class="form-select tom-select">
             @foreach($students as $student)
                 <option value="{{ $student->id }}" {{ old('student_id', optional($application)->student_id) == $student->id ? 'selected' : '' }}>{{ $student->name }}</option>
             @endforeach
@@ -17,7 +17,7 @@
 
     <div class="mb-3">
         <label class="form-label">Institution Name</label>
-        <select name="institution_id" class="form-select">
+        <select name="institution_id" class="form-select tom-select">
             @foreach($institutions as $institution)
                 <option value="{{ $institution->id }}" {{ old('institution_id', optional($application)->institution_id) == $institution->id ? 'selected' : '' }}>{{ $institution->name }}</option>
             @endforeach
@@ -26,7 +26,7 @@
 
     <div class="mb-3">
         <label class="form-label">Status</label>
-        <select name="status" class="form-select">
+        <select name="status" class="form-select tom-select">
             @foreach($statuses as $status)
                 <option value="{{ $status }}" {{ old('status', optional($application)->status) == $status ? 'selected' : '' }}>{{ $status }}</option>
             @endforeach

--- a/resources/views/institution/form.blade.php
+++ b/resources/views/institution/form.blade.php
@@ -15,7 +15,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">City</label>
-        <select name="city" class="form-control">
+        <select name="city" class="form-select tom-select">
             <option value="">-- Select City --</option>
             @foreach($cities as $city)
                 <option value="{{ $city }}" {{ old('city', optional($institution)->city) == $city ? 'selected' : '' }}>{{ $city }}</option>
@@ -24,7 +24,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Province</label>
-        <select name="province" class="form-control">
+        <select name="province" class="form-select tom-select">
             <option value="">-- Select Province --</option>
             @foreach($provinces as $province)
                 <option value="{{ $province }}" {{ old('province', optional($institution)->province) == $province ? 'selected' : '' }}>{{ $province }}</option>

--- a/resources/views/internship/form.blade.php
+++ b/resources/views/internship/form.blade.php
@@ -8,7 +8,7 @@
 
     <div class="mb-3">
         <label class="form-label">Application</label>
-        <select name="application_id" class="form-select" {{ $readonly ? 'disabled' : '' }}>
+        <select name="application_id" class="form-select tom-select" {{ $readonly ? 'disabled' : '' }}>
             @foreach($applications as $application)
                 <option value="{{ $application->id }}" {{ old('application_id', optional($internship)->application_id) == $application->id ? 'selected' : '' }}>{{ $application->student_name }} – {{ $application->institution_name }}</option>
             @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
     <title>@yield('title', 'Internish')</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body>
 @include('layouts.partials.header')

--- a/resources/views/monitoring/form.blade.php
+++ b/resources/views/monitoring/form.blade.php
@@ -8,7 +8,7 @@
 
     <div class="mb-3">
         <label class="form-label">Internship</label>
-        <select name="internship_id" class="form-select" {{ $readonly ? 'disabled' : '' }}>
+        <select name="internship_id" class="form-select tom-select" {{ $readonly ? 'disabled' : '' }}>
             @foreach($internships as $internship)
                 <option value="{{ $internship->id }}" {{ old('internship_id', optional($log)->internship_id) == $internship->id ? 'selected' : '' }}>{{ $internship->student_name }} – {{ $internship->institution_name }}</option>
             @endforeach
@@ -25,7 +25,7 @@
 
     <div class="mb-3">
         <label class="form-label">Supervisor</label>
-        <select name="supervisor_id" class="form-select">
+        <select name="supervisor_id" class="form-select tom-select">
             <option value="">—</option>
             @foreach($supervisors as $supervisor)
                 <option value="{{ $supervisor->id }}" {{ old('supervisor_id', optional($log)->supervisor_id) == $supervisor->id ? 'selected' : '' }}>{{ $supervisor->name }}</option>
@@ -35,7 +35,7 @@
 
     <div class="mb-3">
         <label class="form-label">Tipe</label>
-        <select name="type" class="form-select">
+        <select name="type" class="form-select tom-select">
             @foreach($types as $type)
                 <option value="{{ $type }}" {{ old('type', optional($log)->log_type ?? optional($log)->type) == $type ? 'selected' : '' }}>{{ $type }}</option>
             @endforeach


### PR DESCRIPTION
## Summary
- Load Tom Select assets through Vite and initialise via `window.initTomSelect`
- Add `tom-select` class to searchable `<select>` fields across Institution, Application, Internship and Monitoring forms
- Import Tom Select Bootstrap theme and tweak styles so dropdown search box is visible and matches form-select height

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be32a664c08331a923f86fce006697